### PR TITLE
Add thriftrw.install

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,13 @@
 Releases
 ========
 
-0.1.1 (unreleased)
+0.2.0 (unreleased)
 ------------------
 
 - Export a mapping of constants in the generated module under the ``constants``
   attribute.
+- Added ``thriftrw.install`` to install a Thrift file as a submodule of a
+  module.
 
 
 0.1.0 (2015-08-28)

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -16,6 +16,39 @@ the ``.thrift`` file.
 
 This generates a module which contains the generated types and constants.
 
+Importing generated modules
+---------------------------
+
+When using just :py:func:`thriftrw.load`, you cannot reference the generated
+module in ``import`` statements. For example, the following will not work:
+
+.. code-block:: python
+
+    keyvalue = thriftrw.load('keyvalue.thrift')
+
+    from keyvalue import KeyValue  # ImportError
+
+That's because the system doesn't yet know that the module name ``keyvalue``
+maps to that generated module. This can be remedied by using
+:py:func:`thriftrw.install`.
+
+.. code-block:: python
+
+    # some_module.py
+
+    import thriftrw
+
+    thriftrw.install('keyvalue.thrift')
+
+This will install ``keyvalue`` as a submodule of ``some_module`` so that you
+can do,
+
+.. code-block:: python
+
+    from some_module.keyvalue import KeyValue
+
+For more information, see :py:func:`thriftrw.install`.
+
 What gets generated?
 --------------------
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -38,7 +38,7 @@ maps to that generated module. This can be remedied by using
 
     import thriftrw
 
-    thriftrw.install('keyvalue.thrift')
+    keyvalue = thriftrw.install('keyvalue.thrift')
 
 This will install ``keyvalue`` as a submodule of ``some_module`` so that you
 can do,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import, unicode_literals, print_function
+
+import sys
+
+
+def unimport(*names):
+    """Removes imported modules from ``sys.modules``.
+
+    The given modules and all their parents will be removed from
+    ``sys.modules``.  For example, if ``unimport('os.path')`` is called, both
+    ``os.path`` and ``os`` will be removed from ``sys.modules``.
+
+    The intented use case for this is to tell the system to forget about
+    modules created during tests to ensure that other tests that create
+    similarly named modules don't conflict with existing modules.
+
+    :param names:
+        List of modules to be removed. The given modules and all their parents
+        will be removed.
+    """
+    modules = set()
+    for name in names:
+        parts = name.split('.')
+        while parts:
+            modules.add('.'.join(parts))
+            parts = parts[:-1]
+
+    for module in modules:
+        sys.modules.pop(module, None)
+
+
+def pytest_runtest_teardown(item, nextitem):
+    """Teardown hook for unimport.
+
+    Can be used like so,
+
+    .. code-block:: python
+
+        @pytest.mark.unimport('foo.bar', 'foo.qux')
+        def test_something():
+            from foo.bar import Bar
+
+            # ...
+    """
+    marker = item.get_marker('unimport')
+    if marker:
+        unimport(*marker.args)

--- a/thriftrw/__init__.py
+++ b/thriftrw/__init__.py
@@ -20,9 +20,12 @@
 
 """
 .. autofunction:: load
+
+.. autofunction:: install
 """
 from __future__ import absolute_import, unicode_literals, print_function
 
 from .loader import load
+from .loader import install
 
-__all__ = ['load']
+__all__ = ['load', 'install']

--- a/thriftrw/compile/compiler.py
+++ b/thriftrw/compile/compiler.py
@@ -83,6 +83,9 @@ class Compiler(object):
         :py:class:`thriftrw.spec.ServiceFunction` objects for each method
         defined in the service.
 
+        .. versionadded:: 0.2
+           The ``constants`` attribute in generated modules.
+
         :param str name:
             Name of the Thrift document. This will be the name of the
             generated module.

--- a/thriftrw/loader.py
+++ b/thriftrw/loader.py
@@ -137,6 +137,8 @@ def install(path, name=None):
 
         from foo.my_service import MyService
 
+    .. versionadded:: 0.2
+
     :param path:
         Path of the Thrift file. This may be an absolute path, or a path
         relative to the Python module making the call.

--- a/thriftrw/loader.py
+++ b/thriftrw/loader.py
@@ -19,6 +19,8 @@
 # THE SOFTWARE.
 from __future__ import absolute_import, unicode_literals, print_function
 
+import sys
+import inspect
 import os.path
 
 from .idl import Parser
@@ -108,4 +110,58 @@ _DEFAULT_LOADER = Loader()
 load = _DEFAULT_LOADER.load
 
 
-__all__ = ['Loader', 'load']
+def install(path, name=None):
+    """Compiles a Thrift file and installs it as a submodule of the caller.
+
+    Given a tree organized like so::
+
+        foo/
+            __init__.py
+            bar.py
+            my_service.thrift
+
+    You would do,
+
+    .. code-block:: python
+
+        my_service = thriftrw.install('my_service.thrift')
+
+    To install ``my_service`` as a submodule of the module from which you made
+    the call. If the call was made in ``foo/bar.py``, the compiled
+    Thrift file will be installed as ``foo.bar.my_service``. If the call was
+    made in ``foo/__init__.py``, the compiled Thrift file will be installed as
+    ``foo.my_service``. This allows other modules to import ``from`` the
+    compiled module like so,
+
+    .. code-block:: python
+
+        from foo.my_service import MyService
+
+    :param path:
+        Path of the Thrift file. This may be an absolute path, or a path
+        relative to the Python module making the call.
+    :param str name:
+        Name of the submodule. Defaults to the basename of the Thrift file.
+    :returns:
+        The compiled module
+    """
+    if name is None:
+        name = os.path.splitext(os.path.basename(path))[0]
+
+    callermod = inspect.getmodule(inspect.stack()[1][0])
+    name = '%s.%s' % (callermod.__name__, name)
+
+    if name in sys.modules:
+        return sys.modules[name]
+
+    if not os.path.isabs(path):
+        callerfile = callermod.__file__
+        path = os.path.normpath(
+            os.path.join(os.path.dirname(callerfile), path)
+        )
+
+    sys.modules[name] = mod = load(path, name=name)
+    return mod
+
+
+__all__ = ['Loader', 'load', 'install']


### PR DESCRIPTION
Use case explained in docstring, but this is related to that conversation we had regarding `from <dynamically generated module> import foo`. For TCollector and VCR in the TChannel library, we'll want them to install the Thrift files as submodules in the same way they currently have the Thrift generated code under a subdirectory.

Soliciting opinions on whether you think this is too much magic.

@breerly @blampe 