### PR TITLE
Support oneway functions.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,10 @@
 Releases
 ========
 
-0.2.1 (unreleased)
+0.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support ``oneway`` functions.
 
 
 0.2.0 (2015-09-08)


### PR DESCRIPTION
thriftrw doesn't really care that a function is oneway. That's a TChannel
limitation.

@breerly @blampe 