### PR TITLE
backwards compatibility for unicode struct specs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Releases
 0.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Backwards compatibility for Python 2.7.6 and earlier due to Python #19099.
 
 
 0.3.1 (2015-09-09)

--- a/tests/protocol/test_binary.py
+++ b/tests/protocol/test_binary.py
@@ -366,10 +366,12 @@ def test_unknown_type_id(typ, bytes):
         reader.read(typ)
     assert 'Unknown TType' in str(exc_info)
 
+
 @pytest.mark.parametrize('typ, bytes, value', [
-    (typ, 0x00, vi16(0)) for typ in TType
+    (typ, 0x01, vi16(0)) for typ in TType
 ], ids=reader_writer_ids)
 def test_backwards_compatibility_with_python_266(typ, bytes, value):
+    bytes = bytearray(bytes)
 
     class SawExpectedType(Exception):
         pass

--- a/thriftrw/protocol/binary.py
+++ b/thriftrw/protocol/binary.py
@@ -69,7 +69,7 @@ class BinaryProtocolReader(object):
         :param spec:
             Spec for ``struct.unpack``
         """
-        (result,) = struct.unpack(spec, self._read(num_bytes))
+        (result,) = struct.unpack(str(spec), self._read(num_bytes))
         return result
 
     def _byte(self):
@@ -233,7 +233,7 @@ class BinaryProtocolWriter(V.ValueVisitor):
         :param value:
             Value to pack.
         """
-        self.writer.write(struct.pack(spec, value))
+        self.writer.write(struct.pack(str(spec), value))
 
     def visit_bool(self, value):  # bool:1
         self.visit_byte(1 if value else 0)

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 basepython = python
 deps =
     -rrequirements-test.txt
-    pytest-cov
     coveralls
 commands =
     py.test --cov thriftrw --cov-config .coveragerc --cov-report=xml --cov-report=term-missing tests


### PR DESCRIPTION
@breerly @prashantv @junchaowu 

Need to add a test.

I don't like the repeated `str` calls, might look into ensuring these specs remain bytes.