### PR TITLE
workaround for binary fields defaulting to unicode values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Releases
 0.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Default values for binary fields are no longer unicode.
 
 
 0.3.2 (2015-09-15)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
 doubles
-pytest
+pytest==2.7.3
 pytest-cov==2.1.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
 doubles
 pytest
-pytest-cov
+pytest-cov==2.1.0

--- a/tests/spec/test_const.py
+++ b/tests/spec/test_const.py
@@ -29,6 +29,7 @@ from thriftrw.compile.exceptions import ThriftCompilerError
     'const i32 foo = "hello"',
     'const bool b = 1',
     'const string foo = 42',
+    'const binary foo = 42',
     'const list<string> foo = [1, 2, 3]',
     'const list<string> foo = {"foo": "bar"}',
     'const map<string, i32> foo = {"foo": "bar"}',

--- a/tests/spec/test_struct.py
+++ b/tests/spec/test_struct.py
@@ -21,6 +21,7 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 import pytest
+import six
 
 from thriftrw.compile.exceptions import ThriftCompilerError
 from thriftrw.spec.struct import StructTypeSpec
@@ -245,6 +246,14 @@ def test_default_values(loads):
         (3, TType.BINARY, vbinary(b'world')),
         (4, TType.BINARY, vbinary(b'hello')),
     )
+
+
+def test_default_binary_value(loads):
+    Struct = loads('''struct Struct {
+        1: optional binary field = "";
+    }''').Struct
+
+    assert isinstance(Struct().field, six.binary_type)
 
 
 def test_constructor_behavior(loads):

--- a/thriftrw/spec/struct.py
+++ b/thriftrw/spec/struct.py
@@ -460,7 +460,7 @@ def struct_cls(struct_spec, scope):
         default = None
         if field.default_value is not None:
             if field.ttype_code == TType.BINARY:
-                default = bytes(field.default_value)
+                default = field.default_value.encode('utf-8')
             else:
                 default = field.default_value
 

--- a/thriftrw/spec/struct.py
+++ b/thriftrw/spec/struct.py
@@ -459,10 +459,7 @@ def struct_cls(struct_spec, scope):
 
         default = None
         if field.default_value is not None:
-            if field.ttype_code == TType.BINARY:
-                default = field.default_value.encode('utf-8')
-            else:
-                default = field.default_value
+            default = field.default_value
 
         if field.required and default is None:
             # required fields that have default values are optional as far as

--- a/thriftrw/spec/struct.py
+++ b/thriftrw/spec/struct.py
@@ -211,7 +211,10 @@ class FieldSpec(object):
         if not self.linked:
             self.linked = True
             if self.default_value is not None:
-                self.default_value = self.default_value.link(scope).surface
+                self.default_value = self.default_value.link(
+                    scope,
+                    self.spec
+                ).surface
             self.spec = self.spec.link(scope)
         return self
 

--- a/thriftrw/spec/struct.py
+++ b/thriftrw/spec/struct.py
@@ -459,7 +459,10 @@ def struct_cls(struct_spec, scope):
 
         default = None
         if field.default_value is not None:
-            default = field.default_value
+            if field.ttype_code == TType.BINARY:
+                default = bytes(field.default_value)
+            else:
+                default = field.default_value
 
         if field.required and default is None:
             # required fields that have default values are optional as far as


### PR DESCRIPTION
This is a small workaround to unblock some VCR stuff, @abhinav has a better long-term plan.

@abhinav @breerly 