### PR TITLE
Implement {to,from}_primitive for generated types.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,12 @@
 Releases
 ========
 
-0.3.4 (unreleased)
+0.4.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add ``to_primitive`` and ``from_primitive`` to generated types to allow
+  converting structs, unions, and exceptions to and from primitive
+  representations of their values.
 
 
 0.3.3 (2015-10-05)

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -265,6 +265,82 @@ Constants are made available as-is in the generated module::
 
     LAST_UPDATED = '2015-08-28'
 
+Primitive representations
+-------------------------
+
+.. versionadded:: 0.4
+
+It is sometimes required to convert values of generated types into primitive
+representations of themselves. This may be required so that we can pass the
+value to a serialization library or just to provide a readable reprsentation of
+the value. ``thriftrw`` provides the ``to_primitive`` and ``from_primitive``
+methods on generated types for ``struct``, ``union``, and ``exception`` types
+to do just that.
+
+.. py:method:: to_primitive(self)
+
+    Converts ``self`` into a dictionary mapping field names of the struct,
+    union, or exception, to primitive representations of the field values.
+    Fields with ``None`` values are skipped.
+
+.. py:classmethod:: from_primitive(cls, value)
+
+    Reads a primitive representation of a value of this class. Unrecognized
+    fields are ignored.
+
+For example, given::
+
+
+    struct User {
+        1: required string name
+        2: optional string email
+        3: required bool isActive = true
+    }
+
+We have,
+
+.. code-block:: python
+
+    john = User(name='John Smith', email='john@example.com')
+    assert john.to_primitive() == {
+        'name': 'John Smith',
+        'email': 'john@example.com',
+        'isActive': True,
+    }
+
+    jane = User(
+        name='Jane Smith',
+        email='jane@example.com',
+        isActive=True,
+    )
+    assert jane == User.from_primitive({
+        'name': 'Jane Smith',
+        'email': 'jane@example.com',
+    })
+
+Primitive representations of values are composed of ``bool``, ``bytes``,
+``float``, ``str`` (``unicode`` in Python < 3), ``int``, ``long``, ``dict``,
+and ``list``. The Thrift types map to primitive types like so:
+
+=============   ==============
+Thrift Type     Primitive Type
+=============   ==============
+``bool``        ``bool``
+``byte``        ``int``
+``i16``         ``int``
+``i32``         ``int``
+``i64``         ``long``
+``double``      ``float``
+``string``      ``str`` (``unicode`` in Python < 3)
+``binary``      ``bytes``
+``list``        ``list``
+``map``         ``dict``
+``set``         ``list``
+``struct``      ``dict``
+``union``       ``dict``
+``exception``   ``dict``
+=============   ==============
+
 Differences from Apache Thrift
 ------------------------------
 

--- a/tests/compile/test_spec.py
+++ b/tests/compile/test_spec.py
@@ -29,7 +29,7 @@ from thriftrw.wire import TType
 from ..util.value import *  # noqa
 
 
-@pytest.mark.parametrize('t_spec, value, obj', [
+@pytest.mark.parametrize('args', [
     (spec.BoolTypeSpec, vbool(True), True),
     (spec.BoolTypeSpec, vbool(False), False),
 
@@ -49,7 +49,10 @@ from ..util.value import *  # noqa
      vlist(TType.BYTE, vbyte(1), vbyte(2), vbyte(3)),
      [1, 2, 3]),
 ])
-def test_primitive_wire_conversion(t_spec, value, obj):
+def test_primitive_wire_conversion(args):
+    # workaround for pytest-dev/pytest#1086 until pytest 2.8.2 is released.
+    t_spec, value, obj = args
+
     assert value == t_spec.to_wire(obj)
     assert obj == t_spec.from_wire(value)
 

--- a/tests/spec/test_enum.py
+++ b/tests/spec/test_enum.py
@@ -116,6 +116,10 @@ def test_round_trip(loads):
     assert spec.from_wire(spec.to_wire(Enum.B)) == Enum.B
     assert spec.from_wire(spec.to_wire(Enum.C)) == Enum.C
 
+    assert spec.from_primitive(spec.to_primitive(Enum.A)) == Enum.A
+    assert spec.from_primitive(spec.to_primitive(Enum.B)) == Enum.B
+    assert spec.from_primitive(spec.to_primitive(Enum.C)) == Enum.C
+
 
 def test_enums_are_constants(loads):
     mod = loads('''

--- a/tests/spec/test_list.py
+++ b/tests/spec/test_list.py
@@ -59,3 +59,25 @@ def test_link(parse, scope):
         TType.BINARY, vbinary(b'foo'), vbinary(b'bar')
     )
     assert value == spec.from_wire(spec.to_wire(value))
+
+
+def test_primitive(parse, scope, loads):
+    Foo = loads('struct Foo { 1: required i64 i }').Foo
+    scope.add_type_spec('Foo', Foo.type_spec, 1)
+
+    spec = type_spec_or_ref(parse('list<Foo>')).link(scope)
+
+    value = [
+        Foo(1234),
+        Foo(1234567890),
+        Foo(12345678901234567890),
+    ]
+
+    prim_value = [
+        {'i': 1234},
+        {'i': 1234567890},
+        {'i': 12345678901234567890},
+    ]
+
+    assert spec.to_primitive(value) == prim_value
+    assert spec.from_primitive(prim_value) == value

--- a/tests/spec/test_map.py
+++ b/tests/spec/test_map.py
@@ -69,3 +69,25 @@ def test_link(parse, scope):
         )
     )
     assert value == spec.from_wire(spec.to_wire(value))
+
+
+def test_primitive(parse, scope, loads):
+    Foo = loads('struct Foo { 1: required string bar }').Foo
+    scope.add_type_spec('Foo', Foo.type_spec, 1)
+
+    spec = type_spec_or_ref(parse('map<string, Foo>')).link(scope)
+
+    value = {
+        'a': Foo('1'),
+        'b': Foo('2'),
+        'c': Foo('3'),
+    }
+
+    prim_value = {
+        'a': {'bar': '1'},
+        'b': {'bar': '2'},
+        'c': {'bar': '3'},
+    }
+
+    assert spec.to_primitive(value) == prim_value
+    assert spec.from_primitive(prim_value) == value

--- a/tests/spec/test_primitive.py
+++ b/tests/spec/test_primitive.py
@@ -40,3 +40,15 @@ def test_text_round_trip(s, val, out):
     wire_val = TextTypeSpec.to_wire(s)
     assert wire_val == BinaryValue(val)
     assert TextTypeSpec.from_wire(wire_val) == out
+
+
+@pytest.mark.parametrize('s, prim_s, out_s', [
+    (u'☃', u'☃', None),
+    (b'\xe2\x98\x83', u'☃', u'☃'),
+])
+def test_text_primitive(s, prim_s, out_s):
+    if out_s is None:
+        out_s = s
+
+    assert TextTypeSpec.to_primitive(s) == prim_s
+    assert TextTypeSpec.from_primitive(prim_s) == out_s

--- a/tests/spec/test_primitive.py
+++ b/tests/spec/test_primitive.py
@@ -28,12 +28,14 @@ from thriftrw.spec.primitive import TextTypeSpec
 from thriftrw.wire.value import BinaryValue
 
 
-@pytest.mark.parametrize('s, val, out', [
+@pytest.mark.parametrize('args', [
     (u'☃', b'\xe2\x98\x83', None),
     (b'\xe2\x98\x83', b'\xe2\x98\x83', u'☃'),
     (b'foo', b'foo', u'foo'),
 ])
-def test_text_round_trip(s, val, out):
+def test_text_round_trip(args):
+    # workaround for pytest-dev/pytest#1086 until pytest 2.8.2 is released.
+    s, val, out = args
     if out is None:
         out = s
 
@@ -42,11 +44,13 @@ def test_text_round_trip(s, val, out):
     assert TextTypeSpec.from_wire(wire_val) == out
 
 
-@pytest.mark.parametrize('s, prim_s, out_s', [
+@pytest.mark.parametrize('args', [
     (u'☃', u'☃', None),
     (b'\xe2\x98\x83', u'☃', u'☃'),
 ])
-def test_text_primitive(s, prim_s, out_s):
+def test_text_primitive(args):
+    # workaround for pytest-dev/pytest#1086 until pytest 2.8.2 is released.
+    s, prim_s, out_s = args
     if out_s is None:
         out_s = s
 

--- a/tests/spec/test_set.py
+++ b/tests/spec/test_set.py
@@ -21,6 +21,7 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 import pytest
+from itertools import permutations
 
 from thriftrw.idl import Parser
 from thriftrw.spec import primitive as prim_spec
@@ -65,3 +66,12 @@ def test_link(parse, scope):
         )
     )
     assert value == spec.from_wire(spec.to_wire(value))
+
+
+def test_primitive(parse, scope):
+    ast = parse('set<i32>')
+    spec = type_spec_or_ref(ast).link(scope)
+
+    prim_value = spec.to_primitive(set([1, 2, 3]))
+    assert any(prim_value == list(xs) for xs in permutations([1, 2, 3]))
+    assert spec.from_primitive(prim_value) == set([1, 2, 3])

--- a/tests/spec/test_struct.py
+++ b/tests/spec/test_struct.py
@@ -164,21 +164,35 @@ def test_load_simple(loads):
     assert SimpleStruct('hello', 42) != SimpleStruct('world', 42)
 
 
-def test_simple_to_wire(loads):
-    ToWireStruct = loads('''struct ToWireStruct {
+def test_simple_convert(loads):
+    SimpleStruct = loads('''struct SimpleStruct {
         1: required string a;
         2: optional binary b
-    }''').ToWireStruct
-    spec = ToWireStruct.type_spec
+    }''').SimpleStruct
+    spec = SimpleStruct.type_spec
 
-    assert spec.to_wire(ToWireStruct('hello', b'world')) == vstruct(
-        (1, TType.BINARY, vbinary(b'hello')),
-        (2, TType.BINARY, vbinary(b'world')),
-    )
+    cases = [
+        (
+            SimpleStruct('hello', b'world'),
+            vstruct(
+                (1, TType.BINARY, vbinary(b'hello')),
+                (2, TType.BINARY, vbinary(b'world')),
+            ),
+            {'a': 'hello', 'b': b'world'},
+        ),
+        (
+            SimpleStruct('hello'),
+            vstruct((1, TType.BINARY, vbinary(b'hello'))),
+            {'a': 'hello'},
+        ),
+    ]
 
-    assert spec.to_wire(ToWireStruct('hello')) == vstruct(
-        (1, TType.BINARY, vbinary(b'hello'))
-    )
+    for value, wire_value, prim_value in cases:
+        assert spec.to_wire(value) == wire_value
+        assert value.to_primitive() == prim_value
+
+        assert spec.from_wire(wire_value) == value
+        assert SimpleStruct.from_primitive(prim_value) == value
 
 
 def test_required_field_missing(loads):
@@ -234,18 +248,43 @@ def test_default_values(loads):
     # )
     #
 
-    assert spec.to_wire(Struct('hello')) == vstruct(
-        (2, TType.I64, vi64(42)),
-        (3, TType.BINARY, vbinary(b'')),
-        (4, TType.BINARY, vbinary(b'hello')),
-    )
+    cases = [
+        (
+            Struct('hello'),
+            vstruct(
+                (2, TType.I64, vi64(42)),
+                (3, TType.BINARY, vbinary(b'')),
+                (4, TType.BINARY, vbinary(b'hello')),
+            ),
+            {
+                'optionalFieldWithDefault': 42,
+                'requiredFieldWithDefault': '',
+                'requiredField': 'hello',
+            },
+        ),
+        (
+            Struct('hello', 10, 100, u'world'),
+            vstruct(
+                (1, TType.I32, vi32(10)),
+                (2, TType.I64, vi64(100)),
+                (3, TType.BINARY, vbinary(b'world')),
+                (4, TType.BINARY, vbinary(b'hello')),
+            ),
+            {
+                'optionalField': 10,
+                'optionalFieldWithDefault': 100,
+                'requiredFieldWithDefault': 'world',
+                'requiredField': 'hello',
+            },
+        )
+    ]
 
-    assert spec.to_wire(Struct('hello', 10, 100, u'world')) == vstruct(
-        (1, TType.I32, vi32(10)),
-        (2, TType.I64, vi64(100)),
-        (3, TType.BINARY, vbinary(b'world')),
-        (4, TType.BINARY, vbinary(b'hello')),
-    )
+    for value, wire_value, prim_value in cases:
+        assert spec.to_wire(value) == wire_value
+        assert value.to_primitive() == prim_value
+
+        assert spec.from_wire(wire_value) == value
+        assert Struct.from_primitive(prim_value) == value
 
 
 def test_default_binary_value(loads):
@@ -310,4 +349,19 @@ def test_self_referential(loads):
         )),
     )
 
+    assert c.to_primitive() == {
+        'value': 1,
+        'next': {
+            'value': 2,
+            'next': {
+                'value': 3,
+                'next': {
+                    'value': 4,
+                    'next': {'value': 5},
+                },
+            },
+        },
+    }
+
     assert spec.from_wire(spec.to_wire(c)) == c
+    assert Cons.from_primitive(c.to_primitive()) == c

--- a/thriftrw/spec/base.py
+++ b/thriftrw/spec/base.py
@@ -84,3 +84,34 @@ class TypeSpec(object):
     @abc.abstractmethod
     def link(self, scope):
         pass
+
+    @abc.abstractmethod
+    def to_primitive(self, value):
+        """Converts a value matching this type spec into a primitive value.
+
+        A primitive value is a text, binary, integer, or float value, or a
+        list or dict of other primitive values.
+
+        .. versionadded:: 0.4
+
+        :param value:
+            Value matching this TypeSpec.
+        :returns:
+            A representation of that value using only primitive types, lists,
+            and maps.
+        """
+
+    @abc.abstractmethod
+    def from_primitive(self, prim_value):
+        """Converts a primitive value into a value of this type.
+
+        A primitive value is a text, binary, integer, or float value, or a
+        list or dict of other primitive values.
+
+        .. versionadded:: 0.4
+
+        :param prim_value:
+            A primitive value as produced by ``to_primitive``.
+        :returns:
+            A value matching this TypeSpec.
+        """

--- a/thriftrw/spec/common.py
+++ b/thriftrw/spec/common.py
@@ -55,3 +55,22 @@ def fields_str(cls_name, field_list, include_none=True):
 
         return "%s(%r)" % (cls_name, fields)
     return __str__
+
+
+def to_primitive_method(type_spec):
+    """Generates the ``to_primitive`` method for types given the TypeSpec."""
+
+    def to_primitive(self):
+        return type_spec.to_primitive(self)
+
+    return to_primitive
+
+
+def from_primitive_classmethod():
+    """Generates the ``from_primitive`` classmethod for types."""
+
+    @classmethod
+    def from_primitive(cls, prim_value):
+        return cls.type_spec.from_primitive(prim_value)
+
+    return from_primitive

--- a/thriftrw/spec/enum.py
+++ b/thriftrw/spec/enum.py
@@ -129,9 +129,15 @@ class EnumTypeSpec(TypeSpec):
             )
         return I32Value(value)
 
+    def to_primitive(self, value):
+        return value
+
     def from_wire(self, wire_value):
         check.type_code_matches(self, wire_value)
         return wire_value.value
+
+    def from_primitive(self, prim_value):
+        return prim_value
 
     @classmethod
     def compile(cls, enum):

--- a/thriftrw/spec/list.py
+++ b/thriftrw/spec/list.py
@@ -67,9 +67,15 @@ class ListTypeSpec(TypeSpec):
             values=[self.vspec.to_wire(v) for v in value],
         )
 
+    def to_primitive(self, value):
+        return [self.vspec.to_primitive(x) for x in value]
+
     def from_wire(self, wire_value):
         check.type_code_matches(self, wire_value)
         return [self.vspec.from_wire(v) for v in wire_value.values]
+
+    def from_primitive(self, prim_value):
+        return [self.vspec.from_primitive(v) for v in prim_value]
 
     def __str__(self):
         return 'ListTypeSpec(vspec=%r)' % self.vspec

--- a/thriftrw/spec/map.py
+++ b/thriftrw/spec/map.py
@@ -77,11 +77,23 @@ class MapTypeSpec(TypeSpec):
             ]
         )
 
+    def to_primitive(self, value):
+        return {
+            self.kspec.to_primitive(k): self.vspec.to_primitive(v)
+            for k, v in value.items()
+        }
+
     def from_wire(self, wire_value):
         check.type_code_matches(self, wire_value)
         return {
             self.kspec.from_wire(k): self.vspec.from_wire(v)
             for k, v in wire_value.pairs
+        }
+
+    def from_primitive(self, prim_value):
+        return {
+            self.kspec.from_primitive(k): self.vspec.from_primitive(v)
+            for k, v in prim_value.items()
         }
 
     def __str__(self):

--- a/thriftrw/spec/primitive.py
+++ b/thriftrw/spec/primitive.py
@@ -68,9 +68,15 @@ class PrimitiveTypeSpec(TypeSpec):
         # TODO check bounds for numeric values.
         return self.value_cls(value)
 
+    def to_primitive(self, value):
+        return value
+
     def from_wire(self, wire_value):
         check.type_code_matches(self, wire_value)
         return wire_value.value
+
+    def from_primitive(self, prim_value):
+        return prim_value
 
     def link(self, scope):
         return self
@@ -79,6 +85,9 @@ class PrimitiveTypeSpec(TypeSpec):
         return 'PrimitiveType(%r, %s)' % (self.code, self.value_cls)
 
     __repr__ = __str__
+
+
+# TODO _BinaryTypeSpec
 
 
 class _TextTypeSpec(TypeSpec):
@@ -102,9 +111,21 @@ class _TextTypeSpec(TypeSpec):
             )
         return BinaryValue(value)
 
+    def to_primitive(self, value):
+        if isinstance(value, six.binary_type):
+            value = value.decode('utf-8')
+        elif not isinstance(value, six.text_type):
+            raise TypeError(
+                'Cannot convert %r into a "string".' % (value,)
+            )
+        return value
+
     def from_wire(self, wire_value):
         check.type_code_matches(self, wire_value)
         return wire_value.value.decode('utf-8')
+
+    def from_primitive(self, prim_value):
+        return prim_value
 
     def link(self, scope):
         return self

--- a/thriftrw/spec/set.py
+++ b/thriftrw/spec/set.py
@@ -62,11 +62,17 @@ class SetTypeSpec(TypeSpec):
             values=[self.vspec.to_wire(v) for v in value],
         )
 
+    def to_primitive(self, value):
+        return [self.vspec.to_primitive(x) for x in value]
+
     def from_wire(self, wire_value):
         check.type_code_matches(self, wire_value)
         return set(
             self.vspec.from_wire(v) for v in wire_value.values
         )
+
+    def from_primitive(self, prim_value):
+        return set(self.vspec.from_primitive(v) for v in prim_value)
 
     def __str__(self):
         return 'SetTypeSpec(vspec=%r)' % self.vspec

--- a/thriftrw/spec/struct.py
+++ b/thriftrw/spec/struct.py
@@ -50,6 +50,25 @@ class StructTypeSpec(TypeSpec):
         arguments come next. A TypeError will be raised if the required
         arguments for the struct are not filled with non-None values.
 
+    .. py:method:: to_primitive(self)
+
+        Converts the struct into a dictionary mapping field names to primitive
+        representation of field values.
+
+        Only the following types are used in primitive representations:
+        ``bool``, ``bytes``, ``float``, ``str`` (``unicode`` in Python < 3),
+        ``int``, ``long``, ``dict``, ``list``.
+
+        .. versionadded:: 0.4
+
+    .. py:classmethod:: from_primitive(cls, value)
+
+        Converts a dictionary holding a primitive representation of a value of
+        this type (as returned by ``to_primitive``) into an instance of this
+        class.
+
+        .. versionadded:: 0.4
+
     And obvious definitions of ``__str__`` and ``__eq__``.
 
     Given the definition,::
@@ -153,6 +172,17 @@ class StructTypeSpec(TypeSpec):
 
         return StructValue(fields)
 
+    def to_primitive(self, union):
+        prim = {}
+
+        for field in self.fields:
+            value = getattr(union, field.name)
+            if value is None:
+                continue
+
+            prim[field.name] = field.spec.to_primitive(value)
+        return prim
+
     def from_wire(self, wire_value):
         check.type_code_matches(self, wire_value)
         kwargs = {}
@@ -162,9 +192,18 @@ class StructTypeSpec(TypeSpec):
                 continue
             kwargs[field.name] = field.from_wire(field_value)
 
-        # TODO For the case where cls fails to instantiate because a required
-        # positional argument is missing, we know that the request was
-        # invalid.
+        return self.surface(**kwargs)
+
+    def from_primitive(self, prim_value):
+        # TODO validate is dict?
+        kwargs = {}
+
+        for field in self.fields:
+            field_value = prim_value.get(field.name)
+            if field_value is None:
+                continue
+            kwargs[field.name] = field.spec.from_primitive(field_value)
+
         return self.surface(**kwargs)
 
     def __str__(self):
@@ -476,6 +515,8 @@ def struct_cls(struct_spec, scope):
 
     struct_dct = {}
     struct_dct['type_spec'] = struct_spec
+    struct_dct['to_primitive'] = common.to_primitive_method(struct_spec)
+    struct_dct['from_primitive'] = common.from_primitive_classmethod()
     struct_dct['__slots__'] = tuple(slots)
     struct_dct['__init__'] = struct_init(
         struct_spec.name,

--- a/thriftrw/spec/union.py
+++ b/thriftrw/spec/union.py
@@ -46,6 +46,25 @@ class UnionTypeSpec(TypeSpec):
         Accepts all fields of the unions as keyword arguments but only one of
         them is allowed to be non-None. Positional arguments are not accepted.
 
+    .. py:method:: to_primitive(self)
+
+        Converts the union into a dictionary mapping field names to primitive
+        representation of field values.
+
+        Only the following types are used in primitive representations:
+        ``bool``, ``bytes``, ``float``, ``str`` (``unicode`` in Python < 3),
+        ``int``, ``long``, ``dict``, ``list``.
+
+        .. versionadded:: 0.4
+
+    .. py:classmethod:: from_primitive(cls, value)
+
+        Converts a dictionary holding a primitive representation of a value of
+        this type (as returned by ``to_primitive``) into an instance of this
+        class.
+
+        .. versionadded:: 0.4
+
     And obvious definitions of ``__str__`` and ``__eq__``.
 
     Given the definition,::
@@ -146,6 +165,15 @@ class UnionTypeSpec(TypeSpec):
 
         return StructValue(fields)
 
+    def to_primitive(self, union):
+        for field in self.fields:
+            value = getattr(union, field.name)
+            if value is None:
+                continue
+
+            return {field.name: field.spec.to_primitive(value)}
+        return {}
+
     def from_wire(self, wire_value):
         check.type_code_matches(self, wire_value)
         kwargs = {}
@@ -154,10 +182,21 @@ class UnionTypeSpec(TypeSpec):
             if field_value is None:
                 continue
             kwargs[field.name] = field.from_wire(field_value)
+            break
 
-        # TODO For the case where cls fails to instantiate because a required
-        # positional argument is missing, we know that the request was
-        # invalid.
+        return self.surface(**kwargs)
+
+    def from_primitive(self, prim_value):
+        # TODO validate is dict?
+        kwargs = {}
+
+        for field in self.fields:
+            field_value = prim_value.get(field.name)
+            if field_value is None:
+                continue
+            kwargs[field.name] = field.spec.from_primitive(field_value)
+            break
+
         return self.surface(**kwargs)
 
     def __str__(self):
@@ -266,6 +305,8 @@ def union_cls(union_spec, scope):
 
     union_dct = {}
     union_dct['type_spec'] = union_spec
+    union_dct['to_primitive'] = common.to_primitive_method(union_spec)
+    union_dct['from_primitive'] = common.from_primitive_classmethod()
     union_dct['__slots__'] = tuple(field_names)
     union_dct['__init__'] = union_init(
         union_spec.name, field_names, union_spec.allow_empty


### PR DESCRIPTION
This allows converting values to and from a representation that use only
primtive types, lists, and maps. This representation is easily serializable
into YAML/JSON.

Resolves #14.

TODO: Validation in `to/from_primitive`. The validation logic can probably be shared between the `wire` serialization functions.

CC @breerly @blampe @junchaowu 