### PR TITLE
Validate in struct and union constructors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ Releases
   allow converting struct, union, and exception values to and from primitive
   representations.
 - Added a ``validate`` method to all ``TypeSpecs``.
+- Changed to perform validation during struct, union, or exception construction
+  instead of performing it during serialization.
+- Allow unicode to be passed for ``binary`` types.
 
 
 0.3.3 (2015-10-05)

--- a/tests/spec/test_const.py
+++ b/tests/spec/test_const.py
@@ -40,7 +40,10 @@ def test_type_mismatch(expr, loads):
         loads(expr)
 
     assert 'Value for constant' in str(exc_info)
-    assert 'does not match its type' in str(exc_info)
+    assert (
+        'does not match its type' in str(exc_info) or
+        'is not valid' in str(exc_info)
+    )
 
 
 def test_link(loads):

--- a/tests/spec/test_list.py
+++ b/tests/spec/test_list.py
@@ -83,12 +83,17 @@ def test_primitive(parse, scope, loads):
     assert spec.from_primitive(prim_value) == value
 
 
+def test_from_primitive_invalid(parse, scope):
+    spec = type_spec_or_ref(parse('list<i32>')).link(scope)
+
+    with pytest.raises(ValueError):
+        spec.from_primitive(['a', 'b', 'c'])
+
+
 def test_validate():
     spec = ListTypeSpec(prim_spec.BinaryTypeSpec)
     spec.validate([b'a'])
+    spec.validate([u'a'])
 
     with pytest.raises(TypeError):
-        spec.validate([u'a'])
-
-    with pytest.raises(TypeError):
-        spec.validate('a')
+        spec.validate(42)

--- a/tests/spec/test_struct.py
+++ b/tests/spec/test_struct.py
@@ -209,7 +209,7 @@ def test_required_field_missing(loads):
     x.foo = None
 
     with pytest.raises(TypeError) as exc_info:
-        spec.to_wire(x)
+        spec.validate(x)
 
     assert 'Field "foo" of "X" is required' in str(exc_info)
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -98,7 +98,7 @@ def test_install_absolute(tmpdir, monkeypatch):
 
     thrift_file = module_root.join('service.thrift')
     thrift_file.write(
-        'struct Foo { 1: required string a 2: optional string b }'
+        'struct Foo { 1: required string a; 2: optional string b }'
     )
 
     py_file = module_root.join('bar.py')
@@ -114,7 +114,7 @@ def test_install_absolute(tmpdir, monkeypatch):
 
     from foo.bar.svc import Foo
 
-    assert Foo(a=1) == Foo(a=1)
+    assert Foo(a='bar') == Foo(a='bar')
 
 
 @pytest.mark.unimport('foo.service', 'foo.bar')

--- a/thriftrw/spec/base.py
+++ b/thriftrw/spec/base.py
@@ -62,11 +62,6 @@ class TypeSpec(object):
 
         :returns thriftrw.wire.Value:
             Wire representation of the value.
-        :raises TypeError:
-            If the value did not match the type expected by this TypeSpec.
-        :raises ValueError:
-            If the value matched the type but did not hold the correct set of
-            acceptable values.
         """
 
     @abc.abstractmethod
@@ -123,7 +118,10 @@ class TypeSpec(object):
         :param instance:
             An instance of the type described by this spec.
 
-        Raises a ``TypeError`` or ``ValueError`` if any fields have types that
-        do not match types specified by the Thrift definition.
+        :raises TypeError:
+            If the value did not match the type expected by this TypeSpec.
+        :raises ValueError:
+            If the value matched the type but did not hold the correct set of
+            acceptable values.
         """
         raise NotImplementedError

--- a/thriftrw/spec/const.py
+++ b/thriftrw/spec/const.py
@@ -34,6 +34,7 @@ class ConstValuePrimitive(object):
         self.surface = value
 
     def link(self, scope, type_spec):
+        type_spec.validate(self.surface)
         self.surface = type_spec.from_primitive(
             type_spec.to_primitive(self.surface)
         )
@@ -51,7 +52,7 @@ class ContsValueMap(object):
 
     def link(self, scope, type_spec):
         if not type_spec.ttype_code == TType.MAP:
-            raise TypeError('Expected a map but got %r' % self.surface)
+            raise TypeError('Expected a %s but got a map.' % type_spec.name)
         if not self.linked:
             self.linked = True
             self.surface = {
@@ -75,7 +76,7 @@ class ConstValueList(object):
 
     def link(self, scope, type_spec):
         if not type_spec.ttype_code == TType.LIST:
-            raise TypeError('Expected a list but got %r' % self.surface)
+            raise TypeError('Expected a %s but got a list.' % type_spec.name)
         if not self.linked:
             self.linked = True
             self.surface = [

--- a/thriftrw/spec/const.py
+++ b/thriftrw/spec/const.py
@@ -167,7 +167,7 @@ class ConstSpec(object):
             self.value_spec = self.value_spec.link(scope, self.type_spec)
             value = self.value_spec.surface
             try:
-                self.type_spec.to_wire(value)
+                self.type_spec.validate(value)
             except TypeError as e:
                 raise ThriftCompilerError(
                     'Value for constant "%s" does not match its type "%s": %s'

--- a/thriftrw/spec/enum.py
+++ b/thriftrw/spec/enum.py
@@ -123,7 +123,6 @@ class EnumTypeSpec(TypeSpec):
         return self
 
     def to_wire(self, value):
-        self.validate(value)
         return I32Value(value)
 
     def to_primitive(self, value):

--- a/thriftrw/spec/list.py
+++ b/thriftrw/spec/list.py
@@ -61,7 +61,6 @@ class ListTypeSpec(TypeSpec):
         return 'list<%s>' % self.vspec.name
 
     def to_wire(self, value):
-        check.instanceof_class(self, collections.Sequence, value)
         return ListValue(
             value_ttype=self.vspec.ttype_code,
             values=[self.vspec.to_wire(v) for v in value],

--- a/thriftrw/spec/map.py
+++ b/thriftrw/spec/map.py
@@ -67,7 +67,6 @@ class MapTypeSpec(TypeSpec):
         return self
 
     def to_wire(self, value):
-        check.instanceof_class(self, collections.Mapping, value)
         return MapValue(
             key_ttype=self.kspec.ttype_code,
             value_ttype=self.vspec.ttype_code,

--- a/thriftrw/spec/primitive.py
+++ b/thriftrw/spec/primitive.py
@@ -49,6 +49,10 @@ __all__ = [
 ]
 
 
+if six.PY3:
+    long = int  # No long in Py3.
+
+
 class PrimitiveTypeSpec(TypeSpec):
     """TypeSpec for primitive types."""
 

--- a/thriftrw/spec/primitive.py
+++ b/thriftrw/spec/primitive.py
@@ -21,6 +21,7 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 import six
+import numbers
 
 from thriftrw.wire import TType
 from thriftrw.wire.value import (
@@ -53,20 +54,36 @@ class PrimitiveTypeSpec(TypeSpec):
 
     __slots__ = ('name', 'code', 'value_cls', 'surface')
 
-    def __init__(self, name, code, value_cls, surface):
+    def __init__(self, name, code, value_cls, surface, cast=None):
+        """
+        :param name:
+            Name of the primitive type
+        :param code:
+            TType code used by this primitive
+        :param value_cls:
+            Constructor for wire value types
+        :param surface:
+            Values passed through this spec must be instances of this class or
+            an exception will be raised
+        :param cast:
+            If provided, this is used to cast values into a standard shape
+            before passing them to ``value_cls``
+        """
         self.name = name
         self.code = code
         self.value_cls = value_cls
         self.surface = surface
+
+        if cast is None:
+            cast = (lambda x: x)
+        self.cast = cast
 
     @property
     def ttype_code(self):
         return self.code
 
     def to_wire(self, value):
-        self.validate(value)
-        # TODO check bounds for numeric values.
-        return self.value_cls(value)
+        return self.value_cls(self.cast(value))
 
     def to_primitive(self, value):
         return value
@@ -76,24 +93,41 @@ class PrimitiveTypeSpec(TypeSpec):
         return wire_value.value
 
     def from_primitive(self, prim_value):
-        return prim_value
+        return self.cast(prim_value)
 
     def link(self, scope):
         return self
 
     def validate(self, instance):
+        # TODO check bounds for numeric values
         check.instanceof_surface(self, instance)
 
     def __str__(self):
-        return 'PrimitiveType(%r, %s)' % (self.code, self.value_cls)
+        return 'PrimitiveTypeSpec(%r, %s)' % (self.code, self.value_cls)
 
     __repr__ = __str__
 
 
-# TODO _BinaryTypeSpec
+class _TextualTypeSpec(TypeSpec):
+
+    ttype_code = TType.BINARY
+
+    def link(self, scope):
+        return self
+
+    def to_wire(self, value):
+        if isinstance(value, six.text_type):
+            value = value.encode('utf-8')
+        return BinaryValue(value)
+
+    def validate(self, instance):
+        if not isinstance(instance, (six.binary_type, six.text_type)):
+            raise TypeError(
+                'Cannot convert %r into a "%s".' % (instance, self.name)
+            )
 
 
-class _TextTypeSpec(TypeSpec):
+class _TextTypeSpec(_TextualTypeSpec):
     """TypeSpec for the text type."""
 
     __slots__ = ()
@@ -101,26 +135,9 @@ class _TextTypeSpec(TypeSpec):
     name = 'string'
     surface = six.text_type
 
-    @property
-    def ttype_code(self):
-        return TType.BINARY
-
-    def to_wire(self, value):
-        if isinstance(value, six.text_type):
-            value = value.encode('utf-8')
-        elif not isinstance(value, six.binary_type):
-            raise TypeError(
-                'Cannot serialize %r into a "string".' % (value,)
-            )
-        return BinaryValue(value)
-
     def to_primitive(self, value):
         if isinstance(value, six.binary_type):
             value = value.decode('utf-8')
-        elif not isinstance(value, six.text_type):
-            raise TypeError(
-                'Cannot convert %r into a "string".' % (value,)
-            )
         return value
 
     def from_wire(self, wire_value):
@@ -128,38 +145,67 @@ class _TextTypeSpec(TypeSpec):
         return wire_value.value.decode('utf-8')
 
     def from_primitive(self, prim_value):
+        if isinstance(prim_value, six.binary_type):
+            prim_value = prim_value.decode('utf-8')
         return prim_value
 
-    def link(self, scope):
-        return self
 
-    def validate(self, instance):
-        if not isinstance(instance, six.text_type):
-            raise TypeError()
+class _BinaryTypeSpec(_TextualTypeSpec):
+
+    __slots__ = ()
+
+    name = 'binary'
+    surface = six.binary_type
+
+    def to_primitive(self, value):
+        if isinstance(value, six.text_type):
+            value = value.encode('utf-8')
+        return value
+
+    def from_wire(self, wire_value):
+        check.type_code_matches(self, wire_value)
+        return wire_value.value
+
+    def from_primitive(self, prim_value):
+        if isinstance(prim_value, six.text_type):
+            prim_value = prim_value.encode('utf-8')
+        return prim_value
 
 
 #: TypeSpec for boolean values.
 BoolTypeSpec = PrimitiveTypeSpec('bool', TType.BOOL, BoolValue, bool)
 
 #: TypeSpec for single-byte integers.
-ByteTypeSpec = PrimitiveTypeSpec('byte', TType.BYTE, ByteValue, int)
+ByteTypeSpec = PrimitiveTypeSpec(
+    'byte', TType.BYTE, ByteValue, numbers.Integral, int
+)
 
 #: TypeSpec for floating point numbers with 64 bits of precision.
-DoubleTypeSpec = PrimitiveTypeSpec('double', TType.DOUBLE, DoubleValue, float)
+DoubleTypeSpec = PrimitiveTypeSpec(
+    'double', TType.DOUBLE, DoubleValue, numbers.Number, float
+)
 
 #: TypeSpec for 16-bit integers.
-I16TypeSpec = PrimitiveTypeSpec('i16', TType.I16, I16Value, int)
+I16TypeSpec = PrimitiveTypeSpec(
+    'i16', TType.I16, I16Value, numbers.Integral, int
+)
 
 #: TypeSpec for 32-bit integers.
-I32TypeSpec = PrimitiveTypeSpec('i32', TType.I32, I32Value, int)
+I32TypeSpec = PrimitiveTypeSpec(
+    'i32', TType.I32, I32Value, numbers.Integral, int
+)
 
 #: TypeSpec for 64-bit integers.
-I64TypeSpec = PrimitiveTypeSpec('i64', TType.I64, I64Value, int)
+I64TypeSpec = PrimitiveTypeSpec(
+    'i64', TType.I64, I64Value, numbers.Integral, long
+)
 
 #: TypeSpec for binary blobs.
-BinaryTypeSpec = PrimitiveTypeSpec(
-    'binary', TType.BINARY, BinaryValue, six.binary_type
-)
+#:
+#: .. versionchanged:: 0.4.0
+#:
+#:     Automatically coerces text values into binary.
+BinaryTypeSpec = _BinaryTypeSpec()
 
 #: TypeSpec for unicode data.
 #:

--- a/thriftrw/spec/set.py
+++ b/thriftrw/spec/set.py
@@ -56,7 +56,6 @@ class SetTypeSpec(TypeSpec):
         return 'set<%s>' % self.vspec.name
 
     def to_wire(self, value):
-        check.instanceof_class(self, collections.Set, value)
         return SetValue(
             value_ttype=self.vspec.ttype_code,
             values=[self.vspec.to_wire(v) for v in value],

--- a/thriftrw/spec/struct.py
+++ b/thriftrw/spec/struct.py
@@ -454,8 +454,8 @@ def struct_init(cls_name, field_names, field_defaults, base_cls, validate):
                 'Field(s) %r require non-None values.' % list(unassigned)
             )
 
-        # TODO Instead of validating here, validation should be done while
-        # iterating through fields as values are assigned.
+        # TODO Instead of validating here, validation should be done as values
+        # are assigned.
         validate(self)
 
     # TODO reasonable docstring

--- a/thriftrw/spec/struct.py
+++ b/thriftrw/spec/struct.py
@@ -155,19 +155,12 @@ class StructTypeSpec(TypeSpec):
         return cls(struct.name, fields)
 
     def to_wire(self, struct):
-        check.instanceof_surface(self, struct)
         fields = []
 
         for field in self.fields:
             value = getattr(struct, field.name)
             if value is None:
-                if field.required:
-                    raise TypeError(
-                        'Field "%s" of "%s" is required. It cannot be None.'
-                        % (field.name, self.name)
-                    )
-                else:
-                    continue
+                continue
             fields.append(field.to_wire(value))
 
         return StructValue(fields)
@@ -195,7 +188,6 @@ class StructTypeSpec(TypeSpec):
         return self.surface(**kwargs)
 
     def from_primitive(self, prim_value):
-        # TODO validate is dict?
         kwargs = {}
 
         for field in self.fields:
@@ -207,10 +199,18 @@ class StructTypeSpec(TypeSpec):
         return self.surface(**kwargs)
 
     def validate(self, instance):
+        check.instanceof_surface(self, instance)
+
         for field in self.fields:
             field_value = getattr(instance, field.name)
             if field_value is None:
-                continue
+                if field.required:
+                    raise TypeError(
+                        'Field "%s" of "%s" is required. It cannot be None.'
+                        % (field.name, self.name)
+                    )
+                else:
+                    continue
             field.spec.validate(field_value)
 
     def __str__(self):
@@ -339,7 +339,7 @@ class FieldSpec(object):
         )
 
 
-def struct_init(cls_name, field_names, field_defaults, base_cls):
+def struct_init(cls_name, field_names, field_defaults, base_cls, validate):
     """Generate the ``__init__`` method for structs.
 
     ``field_names`` is a list or tuple of field names for the constructor
@@ -454,6 +454,10 @@ def struct_init(cls_name, field_names, field_defaults, base_cls):
                 'Field(s) %r require non-None values.' % list(unassigned)
             )
 
+        # TODO Instead of validating here, validation should be done while
+        # iterating through fields as values are assigned.
+        validate(self)
+
     # TODO reasonable docstring
     return __init__
 
@@ -530,6 +534,7 @@ def struct_cls(struct_spec, scope):
         field_names,
         field_defaults,
         struct_spec.base_cls,
+        struct_spec.validate,
     )
     struct_dct['__str__'] = common.fields_str(struct_spec.name, field_names)
     struct_dct['__repr__'] = struct_dct['__str__']

--- a/thriftrw/spec/struct.py
+++ b/thriftrw/spec/struct.py
@@ -257,10 +257,22 @@ class FieldSpec(object):
         if not self.linked:
             self.linked = True
             if self.default_value is not None:
-                self.default_value = self.default_value.link(
-                    scope,
-                    self.spec
-                ).surface
+                try:
+                    self.default_value = self.default_value.link(
+                        scope,
+                        self.spec
+                    ).surface
+                except TypeError as e:
+                    raise ThriftCompilerError(
+                        'Default value for field "%s" does not match '
+                        'its type "%s": %s'
+                        % (self.name, self.spec.name, e)
+                    )
+                except ValueError as e:
+                    raise ThriftCompilerError(
+                        'Default value for field "%s" is not valid: %s'
+                        % (self.name, e)
+                    )
             self.spec = self.spec.link(scope)
         return self
 


### PR DESCRIPTION
This makes validation happen in the constructors for struct and union instead of doing it during serialization. The intention is to fail as early as possible.

Also, numeric types are more liberals about what values count as valid. Most integral values can be casted into an i64, for example. We still don't do bounds checks, though.

Finally, `BinaryTypeSpec` was changed to be similar to `TextTypeSpec`. It now accepts unicode and automatically converts it into bytes.

Resolves #31.
Resolves #33.