### PR TITLE
Empty response structs must not be allowed if the return type is not void

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Releases
 ------------------
 
 - Now uses ``io.BytesIO`` for speed improvements in Python 2.
+- Fixed a bug which allowed empty responses for non-void methods.
 
 
 0.4.0 (2015-10-09)

--- a/tests/spec/test_service.py
+++ b/tests/spec/test_service.py
@@ -273,6 +273,19 @@ def test_load(loads):
     ) == KeyValue.healthy.request()
 
 
+def test_fails_on_absent_return_value(loads):
+    m = loads('service Foo { i32 foo(); void bar() }')
+
+    # '\x00' is an empty struct.
+
+    assert m.loads(m.Foo.bar.response, b'\x00') == m.Foo.bar.response()
+
+    with pytest.raises(TypeError) as exc_info:
+        m.loads(m.Foo.foo.response, b'\x00')
+
+    assert 'did not receive any values' in str(exc_info)
+
+
 def assert_round_trip(instance, value):
     assert to_wire(instance) == value
     assert from_wire(instance.__class__, value) == instance

--- a/thriftrw/spec/service.py
+++ b/thriftrw/spec/service.py
@@ -103,7 +103,7 @@ class FunctionResultSpec(UnionTypeSpec):
         result_specs.extend(exceptions)
 
         super(FunctionResultSpec, self).__init__(
-            name, result_specs, allow_empty=True
+            name, result_specs, allow_empty=(return_spec is None)
         )
 
     def link(self, scope):


### PR DESCRIPTION
@blampe @breerly @junchaowu 