### PR TITLE
Fix usage of lists as defaults for sets.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Releases
 0.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Lists and sets now allow arbitrary iterables as input.
+- Lists may be used to provide default values for sets.
 
 
 0.4.1 (2015-10-12)

--- a/tests/spec/test_const.py
+++ b/tests/spec/test_const.py
@@ -48,9 +48,9 @@ def test_type_mismatch(expr, loads):
 
 def test_link(loads):
     mod = loads('''
-        const list<string> lst = [bar, baz, qux];
-
-        const map<i32, string> mp = {
+        const set<string> aSet = [bar, "world", qux];
+        const list<string> aList = [bar, baz, qux];
+        const map<i32, string> aMap = {
             1: bar,
             2: baz,
             3: qux
@@ -84,8 +84,9 @@ def test_link(loads):
     assert mod.a
     assert not mod.b
 
-    assert mod.lst == ['hello', 'hello', 'world']
-    assert mod.mp == {
+    assert mod.aSet == set(["hello", "world"])
+    assert mod.aList == ['hello', 'hello', 'world']
+    assert mod.aMap == {
         1: 'hello',
         2: 'hello',
         3: 'world',
@@ -121,3 +122,11 @@ def test_invalid_enum(loads):
         ''')
 
     assert 'Value for constant "foo" is not valid' in str(exc_info)
+
+
+def test_set_is_transformed(loads):
+    assert loads('''
+        const map<string, set<i32>> some_const = {
+            "foo": [1, 1, 2, 3, 2, 3, 3]
+        };
+    ''').some_const == {'foo': set([1, 2, 3])}

--- a/thriftrw/spec/const.py
+++ b/thriftrw/spec/const.py
@@ -51,10 +51,11 @@ class ContsValueMap(object):
         self.surface = None
 
     def link(self, scope, type_spec):
-        if not type_spec.ttype_code == TType.MAP:
+        if type_spec.ttype_code != TType.MAP:
             raise TypeError('Expected a %s but got a map.' % type_spec.name)
         if not self.linked:
             self.linked = True
+
             self.surface = {
                 k.link(
                     scope,
@@ -62,6 +63,12 @@ class ContsValueMap(object):
                 ).surface: v.link(scope, type_spec.vspec).surface
                 for k, v in self.items.items()
             }
+
+            # Validate it and cast it into whatever the type_spec expects.
+            type_spec.validate(self.surface)
+            self.surface = type_spec.from_primitive(
+                type_spec.to_primitive(self.surface)
+            )
         return self
 
 
@@ -75,13 +82,20 @@ class ConstValueList(object):
         self.surface = None
 
     def link(self, scope, type_spec):
-        if not type_spec.ttype_code == TType.LIST:
+        if type_spec.ttype_code not in (TType.LIST, TType.SET):
             raise TypeError('Expected a %s but got a list.' % type_spec.name)
         if not self.linked:
             self.linked = True
+
             self.surface = [
                 v.link(scope, type_spec.vspec).surface for v in self.values
             ]
+
+            # Validate it and cast it into whatever the type_spec expects.
+            type_spec.validate(self.surface)
+            self.surface = type_spec.from_primitive(
+                type_spec.to_primitive(self.surface)
+            )
         return self
 
 

--- a/thriftrw/spec/list.py
+++ b/thriftrw/spec/list.py
@@ -77,7 +77,7 @@ class ListTypeSpec(TypeSpec):
         return [self.vspec.from_primitive(v) for v in prim_value]
 
     def validate(self, instance):
-        check.instanceof_class(self, collections.Sequence, instance)
+        check.instanceof_class(self, collections.Iterable, instance)
         for v in instance:
             self.vspec.validate(v)
 

--- a/thriftrw/spec/set.py
+++ b/thriftrw/spec/set.py
@@ -74,7 +74,7 @@ class SetTypeSpec(TypeSpec):
         return set(self.vspec.from_primitive(v) for v in prim_value)
 
     def validate(self, instance):
-        check.instanceof_class(self, collections.Set, instance)
+        check.instanceof_class(self, collections.Iterable, instance)
         for v in instance:
             self.vspec.validate(v)
 


### PR DESCRIPTION
@blampe @breerly @junchaowu 

The recent change that validates constants more strictly forgot about lists being used as defaults for sets.