### PR TITLE
Allow numeric defaults for booleans

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,10 @@ Releases
 0.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix a bug in the parser that prevented starting identifier names with
+  ``true`` or ``false``.
+- Allow passing 0 and 1 as default values for ``bool``. These will
+  automatically be casted to boolean.
 
 
 0.5.0 (2015-10-14)

--- a/tests/spec/test_const.py
+++ b/tests/spec/test_const.py
@@ -27,13 +27,13 @@ from thriftrw.errors import ThriftCompilerError
 
 @pytest.mark.parametrize('expr', [
     'const i32 foo = "hello"',
-    'const bool b = 1',
+    'const bool b = "foo"',
     'const string foo = 42',
     'const binary foo = 42',
     'const list<string> foo = [1, 2, 3]',
     'const list<string> foo = {"foo": "bar"}',
     'const map<string, i32> foo = {"foo": "bar"}',
-    'const list<bool> foo = [x]; const i32 x = 42',
+    'const list<bool> foo = [x]; const string x = "bar"',
 ])
 def test_type_mismatch(expr, loads):
     with pytest.raises(ThriftCompilerError) as exc_info:
@@ -59,6 +59,9 @@ def test_link(loads):
         const i32 foo = 42;
         const i32 foo2 = 0x2a;
 
+        const bool true_from_num = 1;
+        const bool false_from_num = 0;
+
         const string baz = bar;
         const string bar = "hello";
         const string qux = "world";
@@ -83,6 +86,9 @@ def test_link(loads):
 
     assert mod.a
     assert not mod.b
+
+    assert mod.true_from_num
+    assert not mod.false_from_num
 
     assert mod.aSet == set(["hello", "world"])
     assert mod.aList == ['hello', 'hello', 'world']

--- a/tests/spec/test_struct.py
+++ b/tests/spec/test_struct.py
@@ -405,7 +405,7 @@ def test_self_referential(loads):
     'struct Foo { 1: optional list<string> foo = {} }',
     'struct Bar { 1: optional list<string> foo = [42] }',
     'struct Baz { 1: optional list<i32> foo = ["a", "b"] }',
-    'struct Foo { 1: required bool bar = 0 }',
+    'struct Foo { 1: required bool bar = "c" }',
 ])
 def test_default_value_type_mismatches(loads, expr):
     with pytest.raises(ThriftCompilerError) as exc_info:

--- a/thriftrw/idl/lexer.py
+++ b/thriftrw/idl/lexer.py
@@ -56,6 +56,8 @@ THRIFT_KEYWORDS = (
     'const',
     'required',
     'optional',
+    'true',
+    'false',
 )
 
 
@@ -67,7 +69,6 @@ class LexerSpec(object):
     literals = ':;,=*{}()<>[]'
 
     tokens = (
-        'BOOLCONSTANT',
         'INTCONSTANT',
         'DUBCONSTANT',
         'LITERAL',
@@ -102,11 +103,6 @@ class LexerSpec(object):
 
     def t_ignore_COMMENT(self, t):
         r'\/\/[^\n]*'
-
-    def t_BOOLCONSTANT(self, t):
-        r'true|false'
-        t.value = t.value == 'true'
-        return t
 
     def t_DUBCONSTANT(self, t):
         r'-?\d+\.\d*(e-?\d+)?'

--- a/thriftrw/idl/parser.py
+++ b/thriftrw/idl/parser.py
@@ -99,6 +99,11 @@ class ParserSpec(object):
         '''
         p[0] = p[1]
 
+    def p_const_bool(self, p):
+        '''const_bool : TRUE
+                      | FALSE'''
+        p[0] = p[1] == 'true'
+
     def p_const(self, p):
         '''const : CONST field_type IDENTIFIER '=' const_value
                  | CONST field_type IDENTIFIER '=' const_value sep'''
@@ -124,7 +129,7 @@ class ParserSpec(object):
         '''const_value_primitive : INTCONSTANT
                                  | DUBCONSTANT
                                  | LITERAL
-                                 | BOOLCONSTANT'''
+                                 | const_bool'''
         p[0] = ast.ConstPrimitiveValue(p[1], lineno=p.lineno(1))
 
     def p_const_list(self, p):

--- a/thriftrw/spec/primitive.pyx
+++ b/thriftrw/spec/primitive.pyx
@@ -176,8 +176,36 @@ class _BinaryTypeSpec(_TextualTypeSpec):
         return prim_value
 
 
+class _BoolTypeSpec(TypeSpec):
+
+    __slots__ = ()
+
+    name = 'bool'
+    surface = bool
+    ttype_code = TType.BOOL
+
+    def to_wire(self, value):
+        return BoolValue(bool(value))
+
+    def to_primitive(self, value):
+        return bool(value)
+
+    def from_wire(self, wire_value):
+        check.type_code_matches(self, wire_value)
+        return wire_value.value
+
+    def from_primitive(self, prim_value):
+        return bool(prim_value)
+
+    def link(self, scope):
+        return self
+
+    def validate(self, instance):
+        check.instanceof_class(self, (bool, int), instance)
+
+
 #: TypeSpec for boolean values.
-BoolTypeSpec = PrimitiveTypeSpec('bool', TType.BOOL, BoolValue, bool)
+BoolTypeSpec = _BoolTypeSpec()
 
 #: TypeSpec for single-byte integers.
 ByteTypeSpec = PrimitiveTypeSpec(


### PR DESCRIPTION
Also, fix parser bug that prevented starting variable names with true or false

@blampe @breerly @junchaowu 