### PR TITLE
Add types and cdefs to wire.value.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,11 @@
 Releases
 ========
 
-0.5.3 (unreleased)
+0.6.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- ``MapValue`` now contains ``MapItem`` objects instead of key-value tuple
+  pairs.
 
 
 0.5.2 (2015-10-19)

--- a/tests/compile/test_spec.py
+++ b/tests/compile/test_spec.py
@@ -22,6 +22,7 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 import pytest
+from itertools import permutations
 
 from thriftrw import spec
 from thriftrw.wire import TType
@@ -85,7 +86,11 @@ def test_map_wire_conversion(t_spec, pairs, obj):
     value = t_spec.to_wire(obj)
     assert ktype == value.key_ttype
     assert vtype == value.value_ttype
-    assert set(pairs) == set(value.pairs)
+    assert any(
+        left == right
+        for left in permutations(pairs)
+        for right in permutations(pairs)
+    )
 
 
 def test_map_from_wire_duplicate_keys():

--- a/tests/protocol/test_binary.py
+++ b/tests/protocol/test_binary.py
@@ -238,7 +238,7 @@ def reader_writer_ids(x):
     ], vset(TType.BOOL, vbool(True), vbool(False), vbool(True))),
 
     # list = vtype:1 count:4 (value){count}
-    (TType.LIST, [0x0C, 0x00, 0x00, 0x00, 0x00], vset(TType.STRUCT)),
+    (TType.LIST, [0x0C, 0x00, 0x00, 0x00, 0x00], vlist(TType.STRUCT)),
     (TType.LIST, [
         0x0C,                       # vtype:1 = struct
         0x00, 0x00, 0x00, 0x02,     # count:4 = 2

--- a/tests/util/value.py
+++ b/tests/util/value.py
@@ -47,7 +47,9 @@ def vlist(typ, *items):
 
 
 def vmap(ktype, vtype, *items):
-    return value.MapValue(ktype, vtype, list(items))
+    return value.MapValue(
+        ktype, vtype, [value.MapItem(k, v) for k, v in items]
+    )
 
 
 def vset(vtype, *items):

--- a/tests/wire/test_value.py
+++ b/tests/wire/test_value.py
@@ -47,11 +47,11 @@ from thriftrw.wire import TType
 
     # Map
     (value.MapValue(TType.BINARY, TType.I16, [
-        (value.BinaryValue('Hello'), value.I16Value(1)),
-        (value.BinaryValue('World'), value.I16Value(2)),
+        value.MapItem(value.BinaryValue(b'Hello'), value.I16Value(1)),
+        value.MapItem(value.BinaryValue(b'World'), value.I16Value(2)),
     ]), 'visit_map', (TType.BINARY, TType.I16, [
-        (value.BinaryValue('Hello'), value.I16Value(1)),
-        (value.BinaryValue('World'), value.I16Value(2)),
+        value.MapItem(value.BinaryValue(b'Hello'), value.I16Value(1)),
+        value.MapItem(value.BinaryValue(b'World'), value.I16Value(2)),
     ])),
 
     # Set
@@ -96,8 +96,8 @@ def test_struct_get():
         value.FieldValue(3, TType.LIST, value.ListValue(
             TType.BINARY,
             [
-                value.BinaryValue('Hello'),
-                value.BinaryValue('World'),
+                value.BinaryValue(b'Hello'),
+                value.BinaryValue(b'World'),
             ]
         )),
     ])
@@ -105,8 +105,8 @@ def test_struct_get():
     assert struct.get(1, TType.BOOL).value
     assert value.ByteValue(42) == struct.get(2, TType.BYTE).value
     assert value.ListValue(TType.BINARY, [
-        value.BinaryValue('Hello'),
-        value.BinaryValue('World'),
+        value.BinaryValue(b'Hello'),
+        value.BinaryValue(b'World'),
     ]) == struct.get(3, TType.LIST).value
 
     assert not struct.get(1, TType.BINARY)

--- a/thriftrw/protocol/binary.pyx
+++ b/thriftrw/protocol/binary.pyx
@@ -142,7 +142,7 @@ class BinaryProtocolReader(object):
         for i in range(length):
             k = key_reader(self)
             v = value_reader(self)
-            pairs.append((k, v))
+            pairs.append(V.MapItem(k, v))
 
         return V.MapValue(
             key_ttype=key_ttype,
@@ -265,15 +265,15 @@ class BinaryProtocolWriter(V.ValueVisitor):
             self.write(field.value)
         self.visit_byte(STRUCT_END)
 
-    def visit_map(self, key_ttype, value_ttype, pairs):
+    def visit_map(self, key_ttype, value_ttype, items):
         # key_type:1 value_type:1 count:4 (key:* value:*){count}
         self.visit_byte(key_ttype)
         self.visit_byte(value_ttype)
-        self.visit_i32(len(pairs))
+        self.visit_i32(len(items))
 
-        for k, v in pairs:
-            self.write(k)
-            self.write(v)
+        for item in items:
+            self.write(item.key)
+            self.write(item.value)
 
     def visit_set(self, value_ttype, values):
         # value_type:1 count:4 (item:*){count}

--- a/thriftrw/spec/map.pyx
+++ b/thriftrw/spec/map.pyx
@@ -23,7 +23,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 import collections
 
 from thriftrw.wire import TType
-from thriftrw.wire.value import MapValue
+from thriftrw.wire.value import MapItem, MapValue
 
 from . import check
 from .base import TypeSpec
@@ -71,7 +71,7 @@ class MapTypeSpec(TypeSpec):
             key_ttype=self.kspec.ttype_code,
             value_ttype=self.vspec.ttype_code,
             pairs=[
-                (self.kspec.to_wire(k), self.vspec.to_wire(v))
+                MapItem(self.kspec.to_wire(k), self.vspec.to_wire(v))
                 for k, v in value.items()
             ]
         )
@@ -85,8 +85,8 @@ class MapTypeSpec(TypeSpec):
     def from_wire(self, wire_value):
         check.type_code_matches(self, wire_value)
         return {
-            self.kspec.from_wire(k): self.vspec.from_wire(v)
-            for k, v in wire_value.pairs
+            self.kspec.from_wire(i.key): self.vspec.from_wire(i.value)
+            for i in wire_value.pairs
         }
 
     def from_primitive(self, prim_value):

--- a/thriftrw/wire/__init__.py
+++ b/thriftrw/wire/__init__.py
@@ -57,6 +57,8 @@ Value Types
 
 .. autoclass:: thriftrw.wire.MapValue
 
+.. autoclass:: thriftrw.wire.MapItem
+
 .. autoclass:: thriftrw.wire.SetValue
 
 .. autoclass:: thriftrw.wire.ListValue

--- a/thriftrw/wire/value.pxd
+++ b/thriftrw/wire/value.pxd
@@ -1,0 +1,96 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import, unicode_literals, print_function
+
+from libc.stdint cimport (
+    int8_t,
+    int16_t,
+    int32_t,
+    int64_t,
+)
+
+
+cdef class Value(object):
+    pass
+
+
+cdef class BoolValue(Value):
+    cdef readonly bint value
+
+
+cdef class ByteValue(Value):
+    cdef readonly int8_t value
+
+
+cdef class DoubleValue(Value):
+    cdef readonly double value
+
+
+cdef class I16Value(Value):
+    cdef readonly int16_t value
+
+
+cdef class I32Value(Value):
+    cdef readonly int32_t value
+
+
+cdef class I64Value(Value):
+    cdef readonly int64_t value
+
+
+cdef class BinaryValue(Value):
+    cdef readonly char* value
+
+    # a reference to the Python object must be maintained to ensure that the
+    # char* doesn't get free-ed
+    cdef bytes _value
+
+
+cdef class FieldValue(object):
+    cdef readonly int16_t id
+    cdef readonly int8_t ttype
+    cdef readonly Value value
+
+
+cdef class StructValue(Value):
+    cdef readonly list fields
+    cdef readonly dict _index
+
+
+cdef class MapItem(object):
+    cdef readonly Value key
+    cdef readonly Value value
+
+
+cdef class MapValue(Value):
+    cdef readonly int8_t key_ttype
+    cdef readonly int8_t value_ttype
+    cdef readonly list pairs
+
+
+cdef class SetValue(Value):
+    cdef readonly int8_t value_ttype
+    cdef readonly list values
+
+
+cdef class ListValue(Value):
+    cdef readonly int8_t value_ttype
+    cdef readonly list values


### PR DESCRIPTION
Also, MapValue now contains a list of MapItems instead of tuples

On my laptop, this brought the median time on the `test_binary_dumps` benchmark down from 396 to 273 microseconds, and the `test_binary_loads` benchmark from 816 to 663 microseconds.

@blampe @breerly @junchaowu 

(More PRs incoming. The intention is to keep the reviews small and self-contained.)