### PR TITLE
Cythonize binary protocol writer

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include README.rst
 include LICENSE
 recursive-include thriftrw *.py
 recursive-include thriftrw *.c
+recursive-include thriftrw *.h

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import glob
+from itertools import chain
+
 from setuptools import setup
 from setuptools import find_packages
 from setuptools.extension import Extension
@@ -20,7 +22,9 @@ try:
 except ImportError:
     extension_filetype = '.c'
 
-for compiled_module in glob.glob('thriftrw/*/*.pyx'):
+for compiled_module in chain(
+    glob.glob('thriftrw/*.pyx'), glob.glob('thriftrw/*/*.pyx')
+):
     ext_modules.extend([
         Extension(
             compiled_module.replace('/', '.')[:-4],
@@ -33,7 +37,8 @@ class sdist(_sdist):
     def run(self):
         try:
             from Cython.Build import cythonize
-            cythonize(['thriftrw/*/*.pyx'])
+            # TODO list Cython modules explicitly
+            cythonize(['thriftrw/*.pyx', 'thriftrw/*/*.pyx'])
         except ImportError:
             pass
         _sdist.run(self)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import, unicode_literals, print_function
+
+from thriftrw._buffer import WriteBuffer
+
+
+def test_empty_buffer():
+    buff = WriteBuffer(10)
+    assert buff.length == 0
+    assert buff.capacity == 10
+    assert buff.value == b''
+
+
+def test_simple_write():
+    buff = WriteBuffer(10)
+    buff.write_bytes(b'hello ')
+    buff.write_bytes(b'world')
+
+    assert buff.value == b'hello world'
+    assert buff.length == 11
+
+
+def test_write_clear():
+    buff = WriteBuffer(10)
+    buff.write_bytes(b'foo')
+    buff.clear()
+
+    assert buff.value == b''
+    assert buff.capacity == 10
+    assert buff.length == 0

--- a/thriftrw/_buffer.pxd
+++ b/thriftrw/_buffer.pxd
@@ -1,0 +1,34 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import, unicode_literals, print_function
+
+
+cdef class WriteBuffer(object):
+    cdef char* data
+    cdef readonly int length, capacity
+
+    cpdef void clear(self)
+
+    cpdef void write_bytes(self, bytes data)
+
+    cdef void write(self, char *data, int count)
+
+    cdef void ensure_capacity(self, int min_bytes)

--- a/thriftrw/_buffer.pyx
+++ b/thriftrw/_buffer.pyx
@@ -1,0 +1,105 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import, unicode_literals, print_function
+
+from libc.stdlib cimport malloc, realloc, free
+from libc.string cimport memcpy
+
+
+cdef int DEFAULT_CAPACITY = 4096  # 4k
+
+
+cdef class WriteBuffer(object):
+    """A write-only in-memory buffer.
+
+    It defaults to a 4k sized buffer.
+
+    The ``value`` attribute makes all data written to the buffer so far
+    available as a Python ``bytes`` object.
+    """
+
+    def __cinit__(self, int init_capacity=0):
+        """
+        :param int init_capacity:
+            Initial capacity of the write buffer.
+        """
+        init_capacity = init_capacity or DEFAULT_CAPACITY
+
+        self.data = <char*>malloc(init_capacity)
+        self.length = 0
+        self.capacity = init_capacity
+
+    def __dealloc__(self):
+        if self.data != NULL:
+            free(self.data)
+            self.data = NULL
+
+    cpdef void clear(self):
+        """Clears the buffer."""
+
+        capacity = self.length + self.capacity
+        self.length = 0
+        self.capacity = capacity
+
+    cpdef void write_bytes(self, bytes data):
+        """Writes the given Python bytes object to the buffer.
+
+        :param bytes data:
+            Data to write to the buffer.
+        """
+        self.write(data, len(data))
+
+    cdef void write(self, char *data, int count):
+        """Writes bytes from the given memory block to the buffer.
+
+        :param int data:
+            Pointer to source data block.
+        :param int count:
+            Number of bytes to write.
+        """
+        self.ensure_capacity(count)
+
+        memcpy(self.data + self.length, data, count)
+        self.length += count
+        self.capacity -= count
+
+    cdef void ensure_capacity(self, int min_bytes):
+        """Ensures that the buffer has enough room for at least ``min_bytes``
+        more bytes.
+        """
+        if min_bytes <= self.capacity:
+            return
+
+        new_total_length = self.length * 2
+        if new_total_length - self.length < min_bytes:
+            # If adding as much room as the current buffer size is not enough,
+            # add just enough room on top.
+            new_total_length += min_bytes
+
+        self.data = <char*>realloc(self.data, new_total_length)
+        self.capacity = new_total_length - self.length
+
+    property value:
+        """Data written to the buffer so far."""
+
+        def __get__(self):
+            cdef bytes out = self.data[:self.length]
+            return out

--- a/thriftrw/_buffer.pyx
+++ b/thriftrw/_buffer.pyx
@@ -20,7 +20,11 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-from libc.stdlib cimport malloc, realloc, free
+from cpython.mem cimport (
+    PyMem_Malloc,
+    PyMem_Realloc,
+    PyMem_Free,
+)
 from libc.string cimport memcpy
 
 
@@ -43,13 +47,13 @@ cdef class WriteBuffer(object):
         """
         init_capacity = init_capacity or DEFAULT_CAPACITY
 
-        self.data = <char*>malloc(init_capacity)
+        self.data = <char*>PyMem_Malloc(init_capacity)
         self.length = 0
         self.capacity = init_capacity
 
     def __dealloc__(self):
         if self.data != NULL:
-            free(self.data)
+            PyMem_Free(self.data)
             self.data = NULL
 
     cpdef void clear(self):
@@ -94,7 +98,7 @@ cdef class WriteBuffer(object):
             # add just enough room on top.
             new_total_length += min_bytes
 
-        self.data = <char*>realloc(self.data, new_total_length)
+        self.data = <char*>PyMem_Realloc(self.data, new_total_length)
         self.capacity = new_total_length - self.length
 
     property value:

--- a/thriftrw/protocol/_endian.h
+++ b/thriftrw/protocol/_endian.h
@@ -1,0 +1,43 @@
+/* Borrowed from thriftpy. */
+
+#if defined(__APPLE__)
+
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+
+#else
+
+#include <endian.h>
+#include <byteswap.h>
+
+#ifndef htobe16
+#define htobe16(x) bswap_16(x)
+#endif
+
+#ifndef htobe32
+#define htobe32(x) bswap_32(x)
+#endif
+
+#ifndef htobe64
+#define htobe64(x) bswap_64(x)
+#endif
+
+#ifndef be16toh
+#define be16toh(x) bswap_16(x)
+#endif
+
+#ifndef be32toh
+#define be32toh(x) bswap_32(x)
+#endif
+
+#ifndef be64toh
+#define be64toh(x) bswap_64(x)
+#endif
+
+#endif

--- a/thriftrw/protocol/_endian.pxd
+++ b/thriftrw/protocol/_endian.pxd
@@ -1,0 +1,36 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import, unicode_literals, print_function
+
+
+from libc.stdint cimport (
+    int16_t,
+    int32_t,
+    int64_t,
+)
+
+cdef extern from "_endian.h":
+    int16_t htobe16(int16_t n)
+    int32_t htobe32(int32_t n)
+    int64_t htobe64(int64_t n)
+    int16_t be16toh(int16_t n)
+    int32_t be32toh(int32_t n)
+    int64_t be64toh(int64_t n)


### PR DESCRIPTION
This brings the median `test_binary_dumps` benchmark time down to 118 microseconds (versus 396 before #61).

- `_buffer` implements a custom write-only in-memory buffer instead of using `BytesIO`.
- `_endian` uses the OS to convert between the host's in-memory representation of numbers to big endian instead of using `struct.pack`.

Depends on #62.