### PR TITLE
Cythonize BinaryProtocolReader

### DIFF
--- a/tests/spec/test_service.py
+++ b/tests/spec/test_service.py
@@ -304,7 +304,7 @@ def test_fails_on_absent_return_value(loads):
     ], vstruct((511, TType.STRUCT, vstruct()))),
 ], ids=['returns-i32', 'returns-void'])
 def test_unrecognized_exception(loads, method, raw, wire_value):
-    raw = bytearray(raw)
+    raw = bytes(bytearray(raw))
 
     m = loads('''
         exception GreatSadness {

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -20,14 +20,26 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
+import pytest
+
+from thriftrw._buffer import ReadBuffer
 from thriftrw._buffer import WriteBuffer
+from thriftrw.errors import EndOfInputError
 
 
-def test_empty_buffer():
+def test_empty_write_buffer():
     buff = WriteBuffer(10)
     assert buff.length == 0
     assert buff.capacity == 10
     assert buff.value == b''
+
+
+def test_empty_read_buffer():
+    buff = ReadBuffer(b'')
+    assert buff.take(0) == b''
+
+    with pytest.raises(EndOfInputError):
+        buff.take(1)
 
 
 def test_simple_write():
@@ -37,6 +49,18 @@ def test_simple_write():
 
     assert buff.value == b'hello world'
     assert buff.length == 11
+
+
+def test_simple_read():
+    buff = ReadBuffer(b'abcd')
+
+    assert buff.take(1) == b'a'
+    assert buff.take(2) == b'bc'
+
+    with pytest.raises(EndOfInputError):
+        buff.take(2)
+
+    assert buff.take(1) == b'd'
 
 
 def test_write_clear():

--- a/thriftrw/_buffer.pxd
+++ b/thriftrw/_buffer.pxd
@@ -21,6 +21,19 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 
+cdef class ReadBuffer(object):
+    cdef char* data
+    cdef int offset, length
+
+    cdef bytes _data
+    # a reference to the original PyObject is required to ensure that the
+    # underlying char* doesn't go away.
+
+    cpdef void read(self, char* dest, int count) except *
+
+    cpdef bytes take(self, int count)
+
+
 cdef class WriteBuffer(object):
     cdef char* data
     cdef readonly int length, capacity
@@ -29,6 +42,6 @@ cdef class WriteBuffer(object):
 
     cpdef void write_bytes(self, bytes data)
 
-    cdef void write(self, char *data, int count)
+    cdef void write(self, char* data, int count)
 
     cdef void ensure_capacity(self, int min_bytes)


### PR DESCRIPTION
This brings the `test_binary_loads` median time down from 816 microseconds before #61 to 445 microseconds.
