### PR TITLE
Provide reference back to FunctionSpec in {Args,Result}Spec

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Releases
 - **Breaking** Removed ``thriftrw.wire.TType`` in favor of the
   ``thriftrw.wire.ttype`` module.
 - Performance improvements to ``BinaryProtocol`` implementation.
+- TypeSpecs for function arguments and results now have a reference back to the
+  function spec itself.
 
 
 0.5.2 (2015-10-19)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Releases
 - Performance improvements to ``BinaryProtocol`` implementation.
 - TypeSpecs for function arguments and results now have a reference back to the
   function spec itself.
+- ServiceSpec now provides a ``lookup`` method to look up the specs for
+  functions defined under that service.
 
 
 0.5.2 (2015-10-19)

--- a/tests/spec/test_service.py
+++ b/tests/spec/test_service.py
@@ -379,3 +379,16 @@ def test_args_and_results_know_function_spec(loads):
         m.S.functionRaisingException.spec is
         m.S.functionRaisingException.response.type_spec.function
     )
+
+
+def test_service_spec_lookup(loads):
+    m = loads('''service S {
+        void foo();
+        void bar();
+    }''')
+
+    service_spec = m.S.service_spec
+
+    assert service_spec.lookup('foo') is m.S.foo.spec
+    assert service_spec.lookup('bar') is m.S.bar.spec
+    assert service_spec.lookup('baz') is None

--- a/tests/spec/test_service.py
+++ b/tests/spec/test_service.py
@@ -328,3 +328,54 @@ def test_unrecognized_exception(loads, method, raw, wire_value):
         in str(exc_info)
     )
     assert exc_info.value.thrift_response == wire_value
+
+
+def test_args_and_results_know_function_spec(loads):
+    m = loads('''
+        exception GreatSadness {
+            1: optional string reason
+        }
+
+        service S {
+            oneway void someOneWayFunction(1: string a);
+
+            void functionReturningVoid(1: i32 a, 2: i64 b);
+
+            string functionReturningNonVoid();
+
+            void functionRaisingException() throws (42: GreatSadness err);
+        }
+    ''')
+
+    assert (
+        m.S.someOneWayFunction.spec is
+        m.S.someOneWayFunction.request.type_spec.function
+    )
+    assert m.S.someOneWayFunction.response is None
+
+    assert (
+        m.S.functionReturningVoid.spec is
+        m.S.functionReturningVoid.request.type_spec.function
+    )
+    assert (
+        m.S.functionReturningVoid.spec is
+        m.S.functionReturningVoid.response.type_spec.function
+    )
+
+    assert (
+        m.S.functionReturningNonVoid.spec is
+        m.S.functionReturningNonVoid.request.type_spec.function
+    )
+    assert (
+        m.S.functionReturningNonVoid.spec is
+        m.S.functionReturningNonVoid.response.type_spec.function
+    )
+
+    assert (
+        m.S.functionRaisingException.spec is
+        m.S.functionRaisingException.request.type_spec.function
+    )
+    assert (
+        m.S.functionRaisingException.spec is
+        m.S.functionRaisingException.response.type_spec.function
+    )

--- a/thriftrw/spec/service.pyx
+++ b/thriftrw/spec/service.pyx
@@ -312,7 +312,10 @@ class ServiceSpec(object):
     function defined in the service.
     """
 
-    __slots__ = ('name', 'functions', 'parent', 'linked', 'surface')
+    __slots__ = (
+        'name', 'functions', 'parent', 'linked', 'surface',
+        '_functions',
+    )
 
     def __init__(self, name, functions, parent):
         #: Name of the service.
@@ -325,6 +328,8 @@ class ServiceSpec(object):
         #: inherit from anything.
         self.parent = parent
 
+        # For quick function lookups.
+        self._functions = None
         self.linked = False
         self.surface = None
 
@@ -360,9 +365,19 @@ class ServiceSpec(object):
                 self.parent = scope.service_specs[self.parent].link(scope)
 
             self.functions = [func.link(scope) for func in self.functions]
+            self._functions = {f.name: f for f in self.functions}
             self.surface = service_cls(self, scope)
 
         return self
+
+    def lookup(self, name):
+        """Look up a function with the given name.
+
+        Returns the function spec or None if no such function exists.
+
+        .. versionadded:: 0.6
+        """
+        return self._functions.get(name, None)
 
     def __str__(self):
         return 'ServiceSpec(name=%r, functions=%r, parent=%r)' % (


### PR DESCRIPTION
Also allow looking up FunctionSpecs given a ServiceSpec.

Needed for #15.