### PR TITLE
Add support for including other Thrift files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ env/
 _build
 *.swp
 node_modules
+*.c
+*.so
+.benchmarks/
+.coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Releases
 0.6.0 (unreleased)
 ------------------
 
+- ``include`` statements are now supported. For more information, see
+  :ref:`including-modules`.
 - Added support for message envelopes. This makes it possible to talk with
   standard Apache Thrift services and clients. For more information, see
   :ref:`calling-apache-thrift`.
@@ -19,6 +21,9 @@ Releases
   ``FunctionSpec``.
 - ``ServiceSpec`` now provides a ``lookup`` method to look up ``FunctionSpecs``
   by name.
+- Removed the ``force`` option on ``Loader.load``.
+- In generated modules, renamed the ``types``, ``constants`` and ``services``
+  attributes to ``__types__``, ``__constants__``, and ``__services__``.
 
 
 0.5.2 (2015-10-19)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint docs docsopen clean
+.PHONY: test lint docs docsopen clean bootstrap
 
 test_args := \
 	--cov thriftrw \
@@ -29,3 +29,9 @@ clean:
 	find tests thriftrw -name \*.c -delete
 	find tests thriftrw -name \*.so -delete
 	make -C docs clean
+
+bootstrap:
+	pip install -r requirements.txt
+	pip install -r requirements-dev.txt
+	pip install -r requirements-test.txt
+	pip install -e .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint docs docsopen clean bootstrap
+.PHONY: test lint docs docsopen clean install
 
 test_args := \
 	--cov thriftrw \
@@ -30,7 +30,7 @@ clean:
 	find tests thriftrw -name \*.so -delete
 	make -C docs clean
 
-bootstrap:
+install:
 	pip install -r requirements.txt
 	pip install -r requirements-dev.txt
 	pip install -r requirements-test.txt

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -194,10 +194,14 @@ Includes
 
 For an include::
 
-    include "shared.thrift"
+    include "./shared.thrift"
 
 The generated module will include a top-level attribute ``shared`` which
 references the generated module for ``shared.thrift``.
+
+Note that paths in include statements are relative to the directory containing
+the Thrift file and they must be in the from ``./foo.thrift``,
+``./foo/bar.thrift``, ``../baz.thrift``, and so on.
 
 Structs
 ~~~~~~~
@@ -449,7 +453,10 @@ Including other Thrift files
 
 Types, services, and constants defined in different Thrift files may be
 referenced by using ``include`` statements with paths **relative to the current
-.thrift file**. Included modules will automatically be compiled along with the
+.thrift file**. The paths must be in the form ``./foo.thrift``,
+``./foo/bar.thrift``, ``../baz.thrift``, and so on.
+
+Included modules will automatically be compiled along with the
 module that included them, and they will be made available in the generated
 module with the base name of the included file.
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -155,20 +155,49 @@ The generated module contains two top-level functions ``dumps`` and ``loads``.
         If the method name was not recognized or any other payload parsing
         errors.
 
-.. py:attribute:: services
+.. py:attribute:: __services__
 
     Collection of all classes generated for all services defined in the source
     thrift file.
 
-.. py:attribute:: types
+    .. versionchanged:: 0.6
+
+        Renamed from ``services`` to ``__services__``.
+
+.. py:attribute:: __types__
 
     Collection of all classes generated for all types defined in the source
     thrift file.
 
-.. py:attribute:: constants
+    .. versionchanged:: 0.6
+
+        Renamed from ``types`` to ``__types__``.
+
+.. py:attribute:: __includes__
+
+    Collection of modules which were referenced via ``include`` statements in
+    the generated module.
+
+    .. versionadded:: 0.6
+
+.. py:attribute:: __constants__
 
     Mapping of constant name to value for all constants defined in the source
     thrift file.
+
+    .. versionchanged:: 0.6
+
+        Renamed from ``constants`` to ``__constants__``.
+
+Includes
+~~~~~~~~
+
+For an include::
+
+    include "shared.thrift"
+
+The generated module will include a top-level attribute ``shared`` which
+references the generated module for ``shared.thrift``.
 
 Structs
 ~~~~~~~
@@ -412,6 +441,56 @@ Thrift Type     Primitive Type
 ``union``       ``dict``
 ``exception``   ``dict``
 =============   ==============
+
+.. _including-modules:
+
+Including other Thrift files
+----------------------------
+
+Types, services, and constants defined in different Thrift files may be
+referenced by using ``include`` statements. Included modules will automatically
+be compiled along with the module that included them, and they will be made
+available in the generated module with the base name of the included file.
+
+For example, given::
+
+    // shared/types.thrift
+
+    struct UUID {
+        1: required i64 high
+        2: required i64 low
+    }
+
+And::
+
+    // service.thrift
+
+    include "shared/types.thrift"
+
+    struct User {
+        1: required types.UUID uuid
+    }
+
+You can do the following
+
+.. code-block:: python
+
+    service = thriftrw.load('service.thrift')
+
+    user_uuid = service.shared.UUID(...)
+    user = service.User(uuid=user_uuid)
+
+    # ...
+
+Also note that you can ``load()`` Thrift files that have already been loaded
+without extra cost because the result is cached by the system.
+
+.. code-block:: python
+
+    service = thriftrw.load('service.thrift')
+    types = thriftrw.load('shared/types.thrift')
+
+    assert service.types is types
 
 .. _calling-apache-thrift:
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -448,9 +448,10 @@ Including other Thrift files
 ----------------------------
 
 Types, services, and constants defined in different Thrift files may be
-referenced by using ``include`` statements. Included modules will automatically
-be compiled along with the module that included them, and they will be made
-available in the generated module with the base name of the included file.
+referenced by using ``include`` statements with paths **relative to the current
+.thrift file**. Included modules will automatically be compiled along with the
+module that included them, and they will be made available in the generated
+module with the base name of the included file.
 
 For example, given::
 
@@ -463,9 +464,9 @@ For example, given::
 
 And::
 
-    // service.thrift
+    // services/user.thrift
 
-    include "shared/types.thrift"
+    include "../shared/types.thrift"
 
     struct User {
         1: required types.UUID uuid
@@ -475,7 +476,7 @@ You can do the following
 
 .. code-block:: python
 
-    service = thriftrw.load('service.thrift')
+    service = thriftrw.load('services/user.thrift')
 
     user_uuid = service.shared.UUID(...)
     user = service.User(uuid=user_uuid)
@@ -487,7 +488,7 @@ without extra cost because the result is cached by the system.
 
 .. code-block:: python
 
-    service = thriftrw.load('service.thrift')
+    service = thriftrw.load('services/user.thrift')
     types = thriftrw.load('shared/types.thrift')
 
     assert service.types is types

--- a/tests/compile/test_compiler.py
+++ b/tests/compile/test_compiler.py
@@ -21,41 +21,11 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 import pytest
-from functools import partial
 
-from thriftrw.idl import Parser
-from thriftrw.protocol import BinaryProtocol
-from thriftrw.compile import Compiler
 from thriftrw.errors import ThriftCompilerError
 
 
 @pytest.fixture
-def parse():
-    return Parser().parse
-
-
-@pytest.fixture
-def compile(request):
-    return partial(Compiler(BinaryProtocol()).compile, request.node.name)
-
-
-@pytest.fixture
-def loads(parse, compile):
-    return (lambda s: compile(parse(s)))
-
-
-def test_include_disallowed(loads):
-    with pytest.raises(ThriftCompilerError) as exc_info:
-        loads('''
-            namespace py foo
-            namespace js bar
-
-            include "foo.thrift"
-        ''')
-
-    assert 'thriftrw does not support including' in str(exc_info)
-
-
 def test_unknown_type(loads):
     with pytest.raises(ThriftCompilerError) as exc_info:
         loads('''
@@ -118,14 +88,14 @@ def test_services_and_types(loads):
         'z': [m.x, m.y],
         'x': 42,
         'y': 123,
-    } == m.constants
+    } == m.__constants__
 
     assert (
-        m.types == (m.Foo, m.Bar) or
-        m.types == (m.Bar, m.Foo)
+        m.__types__ == (m.Foo, m.Bar) or
+        m.__types__ == (m.Bar, m.Foo)
     )
 
     assert (
-        m.services == (m.A, m.B) or
-        m.services == (m.B, m.A)
+        m.__services__ == (m.A, m.B) or
+        m.__services__ == (m.B, m.A)
     )

--- a/tests/compile/test_includes.py
+++ b/tests/compile/test_includes.py
@@ -1,0 +1,398 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import, unicode_literals, print_function
+
+import time
+import pytest
+
+from thriftrw.loader import Loader
+from thriftrw.protocol import BinaryProtocol
+from thriftrw.errors import ThriftCompilerError
+
+
+@pytest.fixture
+def loader():
+    return Loader(BinaryProtocol())
+
+
+def test_simple_include(tmpdir, loader):
+    tmpdir.join('types.thrift').write('''
+        struct Item {
+            1: required string key
+            2: required string value
+        }
+    ''')
+
+    tmpdir.join('svc.thrift').write('''
+        include "types.thrift"
+
+        struct BatchGetResponse {
+            1: required list<types.Item> items = []
+        }
+
+        service ItemStore {
+            BatchGetResponse batchGetItems(1: list<string> keys)
+        }
+    ''')
+
+    svc = loader.load(str(tmpdir.join('svc.thrift')))
+
+    # Loading the module we depend on explicitly should give back the same
+    # generated module.
+    assert svc.types is loader.load(str(tmpdir.join('types.thrift')))
+    assert svc.__includes__ == (svc.types,)
+
+    item = svc.types.Item(key='foo', value='bar')
+    response = svc.BatchGetResponse([item])
+
+    assert svc.types.dumps(item) == bytes(bytearray([
+        # 1: 'foo'
+        0x0B,
+        0x00, 0x01,
+        0x00, 0x00, 0x00, 0x03,
+        0x66, 0x6f, 0x6f,
+
+        # 2: 'bar'
+        0x0B,
+        0x00, 0x02,
+        0x00, 0x00, 0x00, 0x03,
+        0x62, 0x61, 0x72,
+
+        0x00,
+    ]))
+
+    svc.dumps(response) == bytes(bytearray([
+        # 1: [item]
+        0x0F,
+        0x00, 0x01,
+
+        # item
+        0x0C,
+        0x00, 0x00, 0x00, 0x01,
+
+        # 1: 'foo'
+        0x0B,
+        0x00, 0x01,
+        0x00, 0x00, 0x00, 0x03,
+        0x66, 0x6f, 0x6f,
+
+        # 2: 'bar'
+        0x0B,
+        0x00, 0x01,
+        0x00, 0x00, 0x00, 0x03,
+        0x62, 0x61, 0x72,
+
+        0x00,
+    ]))
+
+
+def test_include_relative(tmpdir, loader):
+    tmpdir.join('types/shared.thrift').ensure().write('''
+        typedef i64 Timestamp
+
+        exception InternalError {
+            1: required string message
+        }
+    ''')
+
+    tmpdir.join('team/myservice/myservice.thrift').ensure().write('''
+        include "../../types/shared.thrift"
+
+        service Service {
+            shared.Timestamp getCurrentTime()
+                throws (1: shared.InternalError internalError)
+        }
+    ''')
+
+    myservice = loader.load(
+        str(tmpdir.join('team/myservice/myservice.thrift'))
+    )
+
+    assert myservice.__includes__ == (myservice.shared,)
+
+    myservice.Service.getCurrentTime.response(
+        success=int(time.time() * 1000)
+    )
+
+    myservice.Service.getCurrentTime.response(
+        internalError=myservice.shared.InternalError('great sadness')
+    )
+
+    with pytest.raises(TypeError) as exc_info:
+        myservice.Service.getCurrentTime.response(
+            success='2015-10-29T15:00:00Z'
+        )
+    assert 'Cannot serialize' in str(exc_info)
+
+    with pytest.raises(TypeError) as exc_info:
+        myservice.Service.getCurrentTime.response(
+            internalError=ZeroDivisionError()
+        )
+
+    assert 'Cannot serialize' in str(exc_info)
+
+
+def test_cyclic_includes(tmpdir, loader):
+    tmpdir.join('node.thrift').write('''
+        include "value.thrift"
+
+        struct Node {
+            1: required string name
+            2: required value.Value value
+        }
+    ''')
+
+    tmpdir.join('value.thrift').write('''
+        include "node.thrift"
+
+        struct Value {
+            1: required list<node.Node> nodes
+        }
+    ''')
+
+    node = loader.load(str(tmpdir.join('node.thrift')))
+
+    assert node.__includes__ == (node.value,)
+    assert node.value.__includes__ == (node,)
+
+    assert (
+        node.dumps(node.Node('hello', node.value.Value([]))) ==
+        bytes(bytearray([
+
+            # 1: 'hello'
+            0x0B,
+            0x00, 0x01,
+            0x00, 0x00, 0x00, 0x05,
+            0x68, 0x65, 0x6c, 0x6c, 0x6f,   # 'hello'
+
+            # 2: {1: []}
+            0x0C,
+            0x00, 0x02,
+
+            # 1: []
+            0x0F,
+            0x00, 0x01,
+
+            # []
+            0x0C,
+            0x00, 0x00, 0x00, 0x00,
+
+            0x00,
+
+            0x00,
+        ]))
+    )
+
+
+def test_inherit_included_service(tmpdir, loader):
+    tmpdir.join('common.thrift').write('''
+        service BaseService {
+            string serviceName()
+            bool healthy()
+        }
+    ''')
+
+    tmpdir.join('keyvalue.thrift').write('''
+        include "common.thrift"
+
+        service KeyValue extends common.BaseService {
+            binary get(1: binary key)
+            void put(1: binary key, 2: binary value)
+        }
+    ''')
+
+    keyvalue = loader.load(str(tmpdir.join('keyvalue.thrift')))
+
+    assert keyvalue.__includes__ == (keyvalue.common,)
+
+    assert issubclass(keyvalue.KeyValue, keyvalue.common.BaseService)
+
+    assert (
+        keyvalue.dumps(keyvalue.KeyValue.healthy.response(success=True)) ==
+        bytes(bytearray([0x02, 0x00, 0x00, 0x01, 0x00]))
+    )
+
+
+def test_include_constants(tmpdir, loader):
+    tmpdir.join('bar.thrift').write('const i32 some_num = 42')
+
+    tmpdir.join('foo.thrift').write('''
+        include "bar.thrift"
+
+        const list<i32> nums = [1, bar.some_num, 2];
+    ''')
+
+    foo = loader.load(str(tmpdir.join('foo.thrift')))
+    assert foo.nums == [1, 42, 2] == [1, foo.bar.some_num, 2]
+
+
+def test_multi_level_cyclic_import(tmpdir, loader):
+
+    # |- a.thrift
+    # |- one/
+    #     |- b.thrift
+    #     |- c.thrift
+    #     |- two/
+    #         |- d.thrift
+
+    tmpdir.join('a.thrift').write('''
+        include "one/b.thrift"
+        include "one/c.thrift"
+    ''')
+
+    tmpdir.join('one/b.thrift').ensure().write('''
+        include "two/d.thrift"
+    ''')
+
+    tmpdir.join('one/c.thrift').ensure().write('''
+        include "two/d.thrift"
+    ''')
+
+    tmpdir.join('one/two/d.thrift').ensure().write('''
+        include "../../a.thrift"
+    ''')
+
+    a = loader.load(str(tmpdir.join('a.thrift')))
+    assert (
+        a.__includes__ == (a.b, a.c) or
+        a.__includes__ == (a.c, a.b)
+    )
+
+    assert a.b.d is a.c.d
+
+    assert a.b.__includes__ == (a.b.d,)
+    assert a.c.__includes__ == (a.c.d,)
+
+    assert a.b.d.a is a
+    assert a.c.d.a is a
+    assert a.b.d.__includes__ == (a,)
+    assert a.c.d.__includes__ == (a,)
+
+
+@pytest.mark.parametrize('root, data, msgs', [
+    (
+        # File does not exist
+        'foo.thrift',
+        [('foo.thrift', 'include "bar.thrift"')],
+        [
+            'Cannot include "bar.thrift"',
+            'The file', 'does not exist'
+        ]
+    ),
+    (
+        # Two modules in subdirectories with the same name. This should be
+        # resolved once we implement the "import as" syntax.
+        'index.thrift',
+        [
+            ('foo/shared.thrift', 'typedef string timestamp'),
+            ('bar/shared.thrift', 'typedef string UUID'),
+            ('index.thrift', '''
+                include "foo/shared.thrift"
+                include "bar/shared.thrift"
+            '''),
+        ],
+        [
+            'Cannot include module "shared"',
+            'The name is already taken'
+        ]
+    ),
+    (
+        # Unknown type reference
+        'foo.thrift',
+        [
+            ('foo.thrift', '''
+                include "bar.thrift"
+
+                struct Foo { 1: required bar.Bar b }
+            '''),
+            ('bar.thrift', ''),
+        ],
+        ['Unknown type "Bar" referenced']
+    ),
+    (
+        # Unknown service reference
+        'foo.thrift',
+        [
+            ('foo.thrift', '''
+                include "bar.thrift"
+
+                service Foo extends bar.Bar {
+                }
+            '''),
+            ('bar.thrift', 'service NotBar {}'),
+        ],
+        ['Unknown service "Bar" referenced']
+    ),
+    (
+        # Unknown constant reference
+        'foo.thrift',
+        [
+            ('foo.thrift', '''
+                include "bar.thrift"
+
+                const i32 x = bar.y;
+            '''),
+            ('bar.thrift', 'const i32 z = 42'),
+        ],
+        ['Unknown constant "y" referenced']
+    ),
+    (
+        # Bad type reference
+        'foo.thrift',
+        [('foo.thrift', 'struct Foo { 1: required bar.Bar b }')],
+        ['Unknown type "bar.Bar" referenced']
+    ),
+    (
+        # Bad service reference
+        'foo.thrift',
+        [('foo.thrift', 'service Foo extends bar.Bar {}')],
+        ['Unknown service "bar.Bar" referenced']
+    ),
+    (
+        # Bad constant reference
+        'foo.thrift',
+        [('foo.thrift', 'const i32 x = bar.y')],
+        ['Unknown constant "bar.y" referenced']
+    ),
+])
+def test_bad_includes(tmpdir, loader, root, data, msgs):
+    for path, contents in data:
+        tmpdir.join(path).ensure().write(contents)
+
+    with pytest.raises(ThriftCompilerError) as exc_info:
+        loader.load(str(tmpdir.join(root)))
+
+    for msg in msgs:
+        assert msg in str(exc_info)
+
+
+def test_include_disallowed_with_loads(loads):
+    with pytest.raises(ThriftCompilerError) as exc_info:
+        loads('''
+            namespace py foo
+            namespace js bar
+
+            include "foo.thrift"
+        ''')
+
+    assert (
+        'Includes are not supported when using the "loads()"' in str(exc_info)
+    )

--- a/tests/spec/test_service.py
+++ b/tests/spec/test_service.py
@@ -29,6 +29,7 @@ from thriftrw.spec.reference import TypeReference
 from thriftrw.spec.service import ServiceSpec
 from thriftrw.spec.struct import FieldSpec
 from thriftrw.idl import Parser
+from thriftrw.idl.ast import ServiceReference
 from thriftrw.wire import ttype
 
 from ..util.value import vstruct, vbinary, vmap, vbool
@@ -117,7 +118,7 @@ def test_compile(parse):
     '''))
 
     assert spec.name == 'KeyValue'
-    assert spec.parent == 'BaseService'
+    assert spec.parent == ServiceReference('BaseService', 2)
 
     put_item_spec = spec.functions[0]
     get_item_spec = spec.functions[1]
@@ -161,7 +162,7 @@ def test_link_unknown_parent(loads):
     with pytest.raises(ThriftCompilerError) as exc_info:
         loads('service A extends B {}')
 
-    assert 'Service "A" inherits from unknown service "B"' in str(exc_info)
+    assert 'Unknown service "B" referenced at line' in str(exc_info)
 
 
 def test_load(loads):
@@ -200,8 +201,8 @@ def test_load(loads):
         }
     ''')
     assert (
-        (keyvalue.KeyValue, keyvalue.BaseService) == keyvalue.services or
-        (keyvalue.BaseService, keyvalue.KeyValue) == keyvalue.services
+        (keyvalue.KeyValue, keyvalue.BaseService) == keyvalue.__services__ or
+        (keyvalue.BaseService, keyvalue.KeyValue) == keyvalue.__services__
     )
 
     KeyValue = keyvalue.KeyValue

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -82,13 +82,8 @@ def test_caching(tmpdir, monkeypatch):
     loader = Loader()
 
     mod1 = loader.load(path)
-    assert path in loader.compiled_modules
-
     mod2 = loader.load(path)
     assert mod1 is mod2
-
-    mod3 = loader.load(path, force=True)
-    assert mod3 is not mod2
 
 
 @pytest.mark.unimport('foo.bar.svc')

--- a/thriftrw/_buffer.pyx
+++ b/thriftrw/_buffer.pyx
@@ -152,9 +152,9 @@ cdef class ReadBuffer(object):
             Number of bytes to read.
         :returns:
             ``bytes`` object containing exactly ``count`` bytes.
-        :raises Exception:
+        :raises EndOfInputError:
             If the number of bytes available in the buffer is less than
-            ``count``. TODO more specific exception
+            ``count``.
         """
         if count > self.length - self.offset:
             raise EndOfInputError(

--- a/thriftrw/compile/__init__.py
+++ b/thriftrw/compile/__init__.py
@@ -24,6 +24,7 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 from .compiler import Compiler
+from .scope import Scope
 
 
-__all__ = ['Compiler']
+__all__ = ['Compiler', 'Scope']

--- a/thriftrw/compile/compiler.py
+++ b/thriftrw/compile/compiler.py
@@ -272,6 +272,13 @@ class HeaderProcessor(object):
                 % (include.path, include.lineno)
             )
 
+        if not any(include.path.startswith(p) for p in ('./', '../')):
+            raise ThriftCompilerError(
+                'Paths in include statements are relative to the directory '
+                'containing the Thrift file. They must be in the form '
+                '"./foo.thrift" or "../bar.thrift".'
+            )
+
         # Includes are relative to directory of the Thrift file being
         # compiled.
         path = os.path.join(

--- a/thriftrw/compile/link.py
+++ b/thriftrw/compile/link.py
@@ -47,7 +47,7 @@ class TypeSpecLinker(object):
                 types.append(type_spec.surface)
 
         self.scope.type_specs = type_specs
-        self.scope.add_surface('types', tuple(types))
+        self.scope.add_surface('__types__', tuple(types))
 
 
 class ServiceSpecLinker(object):
@@ -73,7 +73,7 @@ class ServiceSpecLinker(object):
                 services.append(service_spec.surface)
 
         self.scope.service_specs = service_specs
-        self.scope.add_surface('services', tuple(services))
+        self.scope.add_surface('__services__', tuple(services))
 
 
 class ConstSpecLinker(object):
@@ -99,4 +99,4 @@ class ConstSpecLinker(object):
                 constants[const_spec.name] = const_spec.surface
 
         self.scope.const_specs = const_specs
-        self.scope.add_surface('constants', constants)
+        self.scope.add_surface('__constants__', constants)

--- a/thriftrw/idl/__init__.py
+++ b/thriftrw/idl/__init__.py
@@ -60,6 +60,8 @@ Definitions
 
 .. autoclass:: Service
 
+.. autoclass:: ServiceReference
+
 .. autoclass:: Function
 
 .. autoclass:: Field
@@ -104,6 +106,7 @@ from .ast import (
     Union,
     Exc,
     Service,
+    ServiceReference,
     Function,
     Field,
     PrimitiveType,
@@ -134,6 +137,7 @@ __all__ = [
     'Union',
     'Exc',
     'Service',
+    'ServiceReference',
     'Function',
     'Field',
     'PrimitiveType',

--- a/thriftrw/idl/ast.py
+++ b/thriftrw/idl/ast.py
@@ -87,7 +87,7 @@ class Include(namedtuple('Include', 'path lineno')):
 
     ::
 
-        include "common.thrift"
+        include "./common.thrift"
 
     .. py:attribute:: path
 

--- a/thriftrw/idl/ast.py
+++ b/thriftrw/idl/ast.py
@@ -34,6 +34,7 @@ __all__ = [
     'Union',
     'Exc',
     'Service',
+    'ServiceReference',
     'Function',
     'Field',
     'PrimitiveType',
@@ -277,6 +278,15 @@ class Exc(namedtuple('Exc', 'name fields annotations lineno')):
 # defined by Python.
 
 
+class ServiceReference(namedtuple('ServiceReference', 'name lineno')):
+    """A reference to another service.
+
+    .. py:attribute:: name
+
+        Name of the referenced service.
+    """
+
+
 class Service(
     namedtuple('Service', 'name functions parent annotations lineno')
 ):
@@ -293,8 +303,8 @@ class Service(
 
     .. py:attribute:: parent
 
-        Name of the service that this service extends. ``None`` if this service
-        doesn't have a parent service.
+        :py:class:`ServiceReference` to the parent service or ``None`` if this
+        service dosen't have a parent service.
 
     .. py:attribute:: annotations
 

--- a/thriftrw/idl/parser.py
+++ b/thriftrw/idl/parser.py
@@ -235,7 +235,7 @@ class ParserSpec(object):
             p[0] = ast.Service(
                 name=p[2],
                 functions=p[6],
-                parent=p[4],
+                parent=ast.ServiceReference(p[4], p.lineno(4)),
                 annotations=p[8],
                 lineno=p.lineno(2),
             )

--- a/thriftrw/spec/service.pyx
+++ b/thriftrw/spec/service.pyx
@@ -357,12 +357,9 @@ class ServiceSpec(object):
             self.linked = True
 
             if self.parent is not None:
-                if self.parent not in scope.service_specs:
-                    raise ThriftCompilerError(
-                        'Service "%s" inherits from unknown service "%s"'
-                        % (self.name, self.parent)
-                    )
-                self.parent = scope.service_specs[self.parent].link(scope)
+                self.parent = scope.resolve_service_spec(
+                    self.parent.name, self.parent.lineno
+                )
 
             self.functions = [func.link(scope) for func in self.functions]
             self.surface = service_cls(self, scope)


### PR DESCRIPTION
Renamed .{services,types,constants} on generated modules to have `__` at start
and end to avoid naming conflicts.

Removed force flag from load(). The caching behavior is relied upon by the
include logic. Users can instantiate new Loaders if they need the result to
not be cached.

**Update**: After discussion, we decided that relative includes must always start with `./` or `../`. This makes it clearer that the imports are relative to the .thrift file's directory and also allows us to later add different behavior around when `./` and `../` are not specified (like a thrift path environment variable).