### PR TITLE
Fix coverage measurement for Cythonized code

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = true
+plugins = Cython.Coverage
 
 [report]
 exclude_lines =

--- a/tox.ini
+++ b/tox.ini
@@ -18,9 +18,12 @@ deps = -rrequirements-test.txt
 [testenv:cover]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 basepython = python
+setenv =
+    THRIFTRW_COVERAGE=1
 deps =
     -rrequirements-test.txt
     coveralls
+    cython
 commands =
     python setup.py clean --all build_ext --force --inplace
     py.test --cov thriftrw --cov-config .coveragerc --cov-report=xml --cov-report=term-missing tests


### PR DESCRIPTION
The `THRIFTRW_COVERAGE` and `THRIFTRW_PROFILE` environment variables will be used to enable line-tracing hooks and profiling hooks. Line tracking hooks have a performance penalty so they will be used during tests only. Profiling hooks can be used to get meaningful cProfile output out of thriftrw.

It appears that types specified in Cython code count as uncovered code if they're never called with the wrong types (because Cython raises exceptions if types don't match), so the coverage we see here will be lower than before the code was cythonized. 