### PR TITLE
Fix attribute error in ExceptionTypeSpec.__str__

### DIFF
--- a/thriftrw/spec/exc.pyx
+++ b/thriftrw/spec/exc.pyx
@@ -36,10 +36,3 @@ class ExceptionTypeSpec(StructTypeSpec):
     def __init__(self, *args, **kwargs):
         kwargs['base_cls'] = Exception
         super(ExceptionTypeSpec, self).__init__(*args, **kwargs)
-
-    def __str__(self):
-        return 'ExceptionTypeSpec(name=%r, cls=%r, fields=%r)' % (
-            self.name, self.cls, self.fields
-        )
-
-    __repr__ = __str__


### PR DESCRIPTION
Just use the parent's __str__ because it prints the correct class name anyway.

@blampe @breerly @junchaowu 