### PR TITLE
Fix attribute docs for pyx files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ lint:
 	flake8 thriftrw tests
 
 docs:
-	PYTHONDONTWRITEBYTECODE=1 make -C docs html
+	PYTHONDONTWRITEBYTECODE=1 make -C docs html SPHINXOPTS=-W
 
 docszip: docs
 	cd docs/_build/html; zip -r ../html.zip .

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,10 @@ try:
         Extension = Cython.Distutils.Extension
         extension_filetype = '.pyx'
 
-        cython_directives = {}
+        cython_directives = {
+            'embedsignature': True,
+        }
+
         if os.getenv('THRIFTRW_PROFILE'):
             # Add hooks for the profiler in the generated C code.
             cython_directives['profile'] = True

--- a/thriftrw/spec/__init__.py
+++ b/thriftrw/spec/__init__.py
@@ -33,29 +33,48 @@ at the top-level.
 Native types
 ~~~~~~~~~~~~
 
-.. autodata:: thriftrw.spec.BoolTypeSpec
-    :annotation:
+.. data:: thriftrw.spec.BoolTypeSpec
 
-.. autodata:: thriftrw.spec.ByteTypeSpec
-    :annotation:
+    TypeSpec for boolean values.
 
-.. autodata:: thriftrw.spec.DoubleTypeSpec
-    :annotation:
+.. data:: thriftrw.spec.ByteTypeSpec
 
-.. autodata:: thriftrw.spec.I16TypeSpec
-    :annotation:
+    TypeSpec for single-byte integers.
 
-.. autodata:: thriftrw.spec.I32TypeSpec
-    :annotation:
+.. data:: thriftrw.spec.DoubleTypeSpec
 
-.. autodata:: thriftrw.spec.I64TypeSpec
-    :annotation:
+    TypeSpec for floating point numbers with 64 bits of precision.
 
-.. autodata:: thriftrw.spec.BinaryTypeSpec
-    :annotation:
+.. data:: thriftrw.spec.I16TypeSpec
 
-.. autodata:: thriftrw.spec.TextTypeSpec
-    :annotation:
+    TypeSpec for 16-bit integers.
+
+.. data:: thriftrw.spec.I32TypeSpec
+
+    TypeSpec for 32-bit integers.
+
+.. data:: thriftrw.spec.I64TypeSpec
+
+    TypeSpec for 64-bit integers.
+
+.. data:: thriftrw.spec.BinaryTypeSpec
+
+    TypeSpec for binary blobs.
+
+    .. versionchanged:: 0.4.0
+
+        Automatically coerces text values into binary.
+
+.. data:: thriftrw.spec.TextTypeSpec
+
+    TypeSpec for unicode data.
+
+    Values will be decoded/encoded using UTF-8 encoding before/after being
+    serialized/deserialized.
+
+    .. versionchanged:: 0.3.1
+
+        Allows passing binary values directly.
 
 .. autoclass:: thriftrw.spec.ListTypeSpec
     :members:
@@ -99,6 +118,9 @@ Services
 .. autoclass:: thriftrw.spec.FunctionSpec
     :members:
 
+.. autoclass:: thriftrw.spec.FunctionArgsSpec
+    :members:
+
 .. autoclass:: thriftrw.spec.FunctionResultSpec
     :members:
 
@@ -123,6 +145,7 @@ from .typedef import TypedefTypeSpec
 from .service import (
     ServiceSpec,
     FunctionSpec,
+    FunctionArgsSpec,
     FunctionResultSpec,
     ServiceFunction,
 )
@@ -170,6 +193,7 @@ __all__ = [
     # Services
     'ServiceSpec',
     'FunctionSpec',
+    'FunctionArgsSpec',
     'FunctionResultSpec',
     'ServiceFunction',
 

--- a/thriftrw/spec/enum.pyx
+++ b/thriftrw/spec/enum.pyx
@@ -33,7 +33,23 @@ __all__ = ['EnumTypeSpec']
 class EnumTypeSpec(TypeSpec):
     """TypeSpec for enum types.
 
-    The surface for enum types is a class with the following:
+    .. py:attribute:: name
+
+        Name of the enum class.
+
+    .. py:attribute:: items
+
+        Mapping of enum item names to item values.
+
+    .. py:attribute:: values_to_names
+
+        Mapping of enum item values to their names.
+
+    .. py:attribute:: surface
+
+        The surface for this spec.
+
+    The `surface` for enum types is a class with the following:
 
     .. py:attribute:: type_spec
 
@@ -91,10 +107,7 @@ class EnumTypeSpec(TypeSpec):
         assert name
         assert items is not None
 
-        #: Name of the enum class.
         self.name = name
-
-        #: Mapping of enum item names to item values.
         self.items = items
 
         values_to_names = {}
@@ -109,11 +122,8 @@ class EnumTypeSpec(TypeSpec):
                 )
             values_to_names[value] = name
 
-        #: Mapping of enum item values to their names.
         self.values_to_names = values_to_names
         self.linked = False
-
-        #: The surface for this spec.
         self.surface = None
 
     def link(self, scope):

--- a/thriftrw/spec/list.pyx
+++ b/thriftrw/spec/list.pyx
@@ -32,7 +32,13 @@ __all__ = ['ListTypeSpec']
 
 
 class ListTypeSpec(TypeSpec):
-    """Spec for list types."""
+    """Spec for list types.
+
+    .. py:attribute:: vspec
+
+        TypeSpec for the kind of values lists conforming to this spec must
+        contain.
+    """
 
     __slots__ = ('vspec', 'linked')
 
@@ -44,9 +50,6 @@ class ListTypeSpec(TypeSpec):
         :param TypeSpec vspec:
             TypeSpec of values stored in the list.
         """
-
-        #: TypeSpec for the kind of values lists conforming to this spec can
-        #: contain.
         self.vspec = vspec
         self.linked = False
 

--- a/thriftrw/spec/map.pyx
+++ b/thriftrw/spec/map.pyx
@@ -32,7 +32,16 @@ __all__ = ['MapTypeSpec']
 
 
 class MapTypeSpec(TypeSpec):
-    """Spec for map types."""
+    """Spec for map types.
+
+    .. py:attribute:: kspec
+
+        TypeSpec for the kind of keys matching maps must contain.
+
+    .. py:attribute:: vspec
+
+        TypeSpec for the kind of values matching maps must contain.
+    """
 
     __slots__ = ('kspec', 'vspec', 'linked')
 
@@ -46,13 +55,8 @@ class MapTypeSpec(TypeSpec):
         :param TypeSpec vspec:
             TypeSpec of the values in the map.
         """
-
-        #: TypeSpec for the kind of keys matching maps can contain.
         self.kspec = kspec
-
-        #: TypeSpec for the kind of values matching maps can contain.
         self.vspec = vspec
-
         self.linked = False
 
     @property

--- a/thriftrw/spec/primitive.pyx
+++ b/thriftrw/spec/primitive.pyx
@@ -204,47 +204,28 @@ class _BoolTypeSpec(TypeSpec):
         check.instanceof_class(self, (bool, int), instance)
 
 
-#: TypeSpec for boolean values.
 BoolTypeSpec = _BoolTypeSpec()
 
-#: TypeSpec for single-byte integers.
 ByteTypeSpec = PrimitiveTypeSpec(
     'byte', ttype.BYTE, ByteValue, numbers.Integral, int
 )
 
-#: TypeSpec for floating point numbers with 64 bits of precision.
 DoubleTypeSpec = PrimitiveTypeSpec(
     'double', ttype.DOUBLE, DoubleValue, numbers.Number, float
 )
 
-#: TypeSpec for 16-bit integers.
 I16TypeSpec = PrimitiveTypeSpec(
     'i16', ttype.I16, I16Value, numbers.Integral, int
 )
 
-#: TypeSpec for 32-bit integers.
 I32TypeSpec = PrimitiveTypeSpec(
     'i32', ttype.I32, I32Value, numbers.Integral, int
 )
 
-#: TypeSpec for 64-bit integers.
 I64TypeSpec = PrimitiveTypeSpec(
     'i64', ttype.I64, I64Value, numbers.Integral, long
 )
 
-#: TypeSpec for binary blobs.
-#:
-#: .. versionchanged:: 0.4.0
-#:
-#:     Automatically coerces text values into binary.
 BinaryTypeSpec = _BinaryTypeSpec()
 
-#: TypeSpec for unicode data.
-#:
-#: Values will be decoded/encoded using UTF-8 encoding before/after being
-#: serialized/deserialized.
-#:
-#: .. versionchanged:: 0.3.1
-#:
-#:     Allows passing binary values directly.
 TextTypeSpec = _TextTypeSpec()

--- a/thriftrw/spec/struct.pyx
+++ b/thriftrw/spec/struct.pyx
@@ -36,6 +36,15 @@ __all__ = ['StructTypeSpec', 'FieldSpec']
 class StructTypeSpec(TypeSpec):
     """A struct is a collection of named fields.
 
+    .. py:attribute:: name
+
+        Name of the struct.
+
+    .. py:attribute:: fields
+
+        Collection of :py:class:`FieldSpec` objects representing the fields of
+        this struct.
+
     The surface for struct types is a class with the following:
 
     .. py:attribute:: type_spec
@@ -110,10 +119,7 @@ class StructTypeSpec(TypeSpec):
             Base class to use for generates classes. Defaults to ``object``.
         """
 
-        #: Name of the struct.
         self.name = name
-
-        #: Collection of :py:class:`FieldSpec` objects.
         self.fields = fields
         self.linked = False
         self.surface = None
@@ -232,27 +238,35 @@ class StructTypeSpec(TypeSpec):
 class FieldSpec(object):
     """Specification for a single field on a struct.
 
-    FieldSpecs do not expose anything at the module level.
+    .. py:attribute:: id
+
+        Field identifier of this field.
+
+    .. py:attribute:: name
+
+        Name of the field.
+
+    .. py:attribute:: spec
+
+        :py:class:`TypeSpec` for the type of values accepted by this field.
+
+    .. py:attribute:: required
+
+        Whether this field is required or not.
+
+    .. py:attribute:: default_value
+
+        Default value of the field if any. None otherwise.
     """
 
     __slots__ = ('id', 'name', 'spec', 'required', 'default_value', 'linked')
 
     def __init__(self, id, name, spec, required, default_value=None):
-        #: Field identifier of the field.
         self.id = id
-
-        #: Name of the field.
         self.name = name
-
-        #: TypeSpec for the type of values accepted by the field.
         self.spec = spec
-
-        #: Whether this field is required or not.
         self.required = required
-
-        #: Default value of the field.
         self.default_value = default_value
-
         self.linked = False
 
     def link(self, scope):


### PR DESCRIPTION
I realized that the docs for all attributes have been broken since we went
cython. "#:"-style docstrings don't work with the pyx files presumably because
Sphinx doesn't have access to the original file's source at doc generation
time.