### PR TITLE
Expose .thrift file source under __thrift_source__ in generated modules.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Releases
 ------------------
 
 - Expose ``result_type`` on the args type for service functions.
+- Expose the contents of the Thrift file on compiled modules under the
+  ``__thrift_source__`` attribute.
 
 
 1.0.1 (2015-12-11)

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -180,6 +180,12 @@ The generated module contains two top-level functions ``dumps`` and ``loads``.
 
     .. versionadded:: 1.0
 
+.. py:attribute:: __thrift_source__
+
+    Contents of the .thrift file from which this module was compiled.
+
+    .. versionadded:: 1.1
+
 .. py:attribute:: __constants__
 
     Mapping of constant name to value for all constants defined in the source

--- a/tests/compile/test_compiler.py
+++ b/tests/compile/test_compiler.py
@@ -72,7 +72,7 @@ def test_service_type_conflict(loads):
 
 
 def test_services_and_types(loads):
-    m = loads('''
+    s = '''
         struct Foo {}
         union Bar {}
 
@@ -82,7 +82,8 @@ def test_services_and_types(loads):
         const list<i32> z = [x, y];
         const i32 x = 42;
         const i32 y = 123;
-    ''')
+    '''
+    m = loads(s)
 
     assert {
         'z': [m.x, m.y],
@@ -99,3 +100,5 @@ def test_services_and_types(loads):
         m.__services__ == (m.A, m.B) or
         m.__services__ == (m.B, m.A)
     )
+
+    assert m.__thrift_source__ == s


### PR DESCRIPTION
Resolves #66.