### PR TITLE
Add i8 as alias for byte.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ Releases
   ``__thrift_source__`` attribute.
 - Don't fail compilation if fields in unions specify themselves as
   ``optional``.
+- Added ``i8`` as an alias for ``byte`` in Thrift files.
+- Fixed a bug where the line number of constant lists and maps was incorrect in
+  the AST.
 
 
 1.0.1 (2015-12-11)

--- a/thriftrw/idl/ast.py
+++ b/thriftrw/idl/ast.py
@@ -550,7 +550,7 @@ class ConstMap(namedtuple('ConstList', 'pairs lineno'), ConstValue):
 
     .. py:attribute:: pairs
 
-        Collection of pairs of ``ConstValue`` objects.
+        Dictionary mapping ``ConstValue`` keys to ``ConstValue`` values.
     """
 
     def apply(self, visitor):

--- a/thriftrw/idl/lexer.py
+++ b/thriftrw/idl/lexer.py
@@ -35,6 +35,7 @@ THRIFT_KEYWORDS = (
     'void',
     'bool',
     'byte',
+    'i8',
     'i16',
     'i32',
     'i64',

--- a/thriftrw/idl/parser.py
+++ b/thriftrw/idl/parser.py
@@ -138,7 +138,7 @@ class ParserSpec(object):
 
     def p_const_list(self, p):
         '''const_list : '[' const_list_seq ']' '''
-        p[0] = ast.ConstList(list(p[2]), p.lineno(2))
+        p[0] = ast.ConstList(list(p[2]), p.lineno(1))
 
     def p_const_list_seq(self, p):
         '''const_list_seq : const_value sep const_list_seq
@@ -148,7 +148,7 @@ class ParserSpec(object):
 
     def p_const_map(self, p):
         '''const_map : '{' const_map_seq '}' '''
-        p[0] = ast.ConstMap(dict(p[2]), p.lineno(2))
+        p[0] = ast.ConstMap(dict(p[2]), p.lineno(1))
 
     def p_const_map_seq(self, p):
         '''const_map_seq : const_map_item sep const_map_seq
@@ -350,6 +350,7 @@ class ParserSpec(object):
     def p_base_type(self, p):  # noqa
         '''base_type : BOOL annotations
                      | BYTE annotations
+                     | I8 annotations
                      | I16 annotations
                      | I32 annotations
                      | I64 annotations
@@ -357,7 +358,11 @@ class ParserSpec(object):
                      | STRING annotations
                      | BINARY annotations'''
 
-        p[0] = ast.PrimitiveType(p[1], p[2])
+        name = p[1]
+        if name == 'i8':
+            name = 'byte'
+
+        p[0] = ast.PrimitiveType(name, p[2])
 
     def p_container_type(self, p):
         '''container_type : map_type


### PR DESCRIPTION
Also, found a bug where the line number for constant maps and lists was wrong.
Fixed that too.

Resolves #94.