### PR TITLE
Move FieldSpec to separate module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ cython_modules = [
     'thriftrw.spec.common',
     'thriftrw.spec.enum',
     'thriftrw.spec.exc',
+    'thriftrw.spec.field',
     'thriftrw.spec.list',
     'thriftrw.spec.map',
     'thriftrw.spec.primitive',

--- a/tests/spec/test_exc.py
+++ b/tests/spec/test_exc.py
@@ -24,7 +24,7 @@ import pytest
 
 from thriftrw.idl import Parser
 from thriftrw.spec.exc import ExceptionTypeSpec
-from thriftrw.spec.struct import FieldSpec
+from thriftrw.spec.field import FieldSpec
 from thriftrw.spec import primitive as prim_spec
 
 

--- a/tests/spec/test_service.py
+++ b/tests/spec/test_service.py
@@ -27,7 +27,7 @@ from thriftrw.errors import ThriftCompilerError
 from thriftrw.errors import UnknownExceptionError
 from thriftrw.spec.reference import TypeReference
 from thriftrw.spec.service import ServiceSpec
-from thriftrw.spec.struct import FieldSpec
+from thriftrw.spec.field import FieldSpec
 from thriftrw.idl import Parser
 from thriftrw.idl.ast import ServiceReference
 from thriftrw.wire import ttype

--- a/tests/spec/test_struct.py
+++ b/tests/spec/test_struct.py
@@ -25,7 +25,7 @@ import six
 
 from thriftrw.errors import ThriftCompilerError
 from thriftrw.spec.struct import StructTypeSpec
-from thriftrw.spec.struct import FieldSpec
+from thriftrw.spec.field import FieldSpec
 from thriftrw.idl import Parser
 from thriftrw.spec import primitive as prim_spec
 from thriftrw.spec.reference import TypeReference

--- a/tests/spec/test_union.py
+++ b/tests/spec/test_union.py
@@ -24,7 +24,7 @@ import pytest
 
 from thriftrw.idl import Parser
 from thriftrw.spec.union import UnionTypeSpec
-from thriftrw.spec.struct import FieldSpec
+from thriftrw.spec.field import FieldSpec
 from thriftrw.spec.reference import TypeReference
 from thriftrw.errors import ThriftCompilerError
 from thriftrw.spec import primitive as prim_spec

--- a/thriftrw/spec/__init__.py
+++ b/thriftrw/spec/__init__.py
@@ -135,10 +135,11 @@ from __future__ import absolute_import, unicode_literals, print_function
 from .base import TypeSpec
 from .const import ConstSpec
 from .enum import EnumTypeSpec
+from .field import FieldSpec
 from .list import ListTypeSpec
 from .map import MapTypeSpec
 from .set import SetTypeSpec
-from .struct import StructTypeSpec, FieldSpec
+from .struct import StructTypeSpec
 from .exc import ExceptionTypeSpec
 from .union import UnionTypeSpec
 from .typedef import TypedefTypeSpec

--- a/thriftrw/spec/enum.pyx
+++ b/thriftrw/spec/enum.pyx
@@ -21,7 +21,7 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 from thriftrw.wire cimport ttype
-from thriftrw.wire.value import I32Value
+from thriftrw.wire.value cimport I32Value
 
 from . import check
 from .base import TypeSpec

--- a/thriftrw/spec/field.pyx
+++ b/thriftrw/spec/field.pyx
@@ -1,0 +1,159 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import, unicode_literals, print_function
+
+from thriftrw.wire.value cimport FieldValue
+
+from .const import const_value_or_ref
+from .spec_mapper import type_spec_or_ref
+from ..errors import ThriftCompilerError
+
+
+class FieldSpec(object):
+    """Specification for a single field on a struct.
+
+    .. py:attribute:: id
+
+        Field identifier of this field.
+
+    .. py:attribute:: name
+
+        Name of the field.
+
+    .. py:attribute:: spec
+
+        :py:class:`TypeSpec` for the type of values accepted by this field.
+
+    .. py:attribute:: required
+
+        Whether this field is required or not.
+
+    .. py:attribute:: default_value
+
+        Default value of the field if any. None otherwise.
+    """
+
+    __slots__ = ('id', 'name', 'spec', 'required', 'default_value', 'linked')
+
+    def __init__(self, id, name, spec, required, default_value=None):
+        self.id = id
+        self.name = name
+        self.spec = spec
+        self.required = required
+        self.default_value = default_value
+        self.linked = False
+
+    def link(self, scope):
+        if not self.linked:
+            self.linked = True
+            self.spec = self.spec.link(scope)
+            if self.default_value is not None:
+                try:
+                    self.default_value = self.default_value.link(
+                        scope,
+                        self.spec
+                    ).surface
+                except TypeError as e:
+                    raise ThriftCompilerError(
+                        'Default value for field "%s" does not match '
+                        'its type "%s": %s'
+                        % (self.name, self.spec.name, e)
+                    )
+                except ValueError as e:
+                    raise ThriftCompilerError(
+                        'Default value for field "%s" is not valid: %s'
+                        % (self.name, e)
+                    )
+        return self
+
+    @property
+    def ttype_code(self):
+        return self.spec.ttype_code
+
+    @classmethod
+    def compile(cls, field, struct_name, require_requiredness=True):
+        if field.id is None:
+            raise ThriftCompilerError(
+                'Field "%s" of "%s" does not have an explicit field ID. '
+                'Please specify the numeric ID for the field.'
+                % (field.name, struct_name)
+            )
+
+        required = field.requiredness
+        if required is None:
+            if require_requiredness:
+                raise ThriftCompilerError(
+                    'Field "%s" of "%s" on line %d does not explicitly '
+                    'specify requiredness. Please specify whether the field '
+                    'is optional or required in the IDL.'
+                    % (field.name, struct_name, field.lineno)
+                )
+            else:
+                required = False
+
+        # TODO check field ids are valid signed 16-bit integers
+
+        default_value = None
+        if field.default is not None:
+            default_value = const_value_or_ref(field.default)
+
+        field_type_spec = type_spec_or_ref(field.field_type)
+        return cls(
+            id=field.id,
+            name=field.name,
+            spec=field_type_spec,
+            required=required,
+            default_value=default_value,
+        )
+
+    # While FieldSpec has an interface similar to TypeSpec, it's not an actual
+    # TypeSpec.
+
+    def to_wire(self, value):
+        assert value is not None
+        return FieldValue(
+            id=self.id,
+            ttype=self.spec.ttype_code,
+            value=self.spec.to_wire(value),
+        )
+
+    def from_wire(self, wire_value):
+        assert wire_value is not None
+        return self.spec.from_wire(wire_value.value)
+
+    def __str__(self):
+        # Field __str__ must reference spec names instead of the specs to
+        # avoid an infinite loop in case the field is self-referential.
+        return 'FieldSpec(id=%r, name=%r, spec_name=%r)' % (
+            self.id, self.name, self.spec.name
+        )
+
+    __repr__ = __str__
+
+    def __eq__(self, other):
+        return (
+            self.id == other.id and
+            self.name == other.name and
+            self.spec == other.spec and
+            self.required == other.required and
+            self.default_value == other.default_value and
+            self.linked == other.linked
+        )

--- a/thriftrw/spec/list.pyx
+++ b/thriftrw/spec/list.pyx
@@ -23,7 +23,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 import collections
 
 from thriftrw.wire cimport ttype
-from thriftrw.wire.value import ListValue
+from thriftrw.wire.value cimport ListValue
 
 from . import check
 from .base import TypeSpec

--- a/thriftrw/spec/map.pyx
+++ b/thriftrw/spec/map.pyx
@@ -23,7 +23,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 import collections
 
 from thriftrw.wire cimport ttype
-from thriftrw.wire.value import MapItem, MapValue
+from thriftrw.wire.value cimport MapItem, MapValue
 
 from . import check
 from .base import TypeSpec

--- a/thriftrw/spec/primitive.pyx
+++ b/thriftrw/spec/primitive.pyx
@@ -24,7 +24,7 @@ import six
 import numbers
 
 from thriftrw.wire cimport ttype
-from thriftrw.wire.value import (
+from thriftrw.wire.value cimport (
     BoolValue,
     ByteValue,
     DoubleValue,

--- a/thriftrw/spec/service.pyx
+++ b/thriftrw/spec/service.pyx
@@ -24,7 +24,8 @@ from collections import namedtuple
 
 from . import check
 from .spec_mapper import type_spec_or_ref
-from .struct import StructTypeSpec, FieldSpec
+from .field import FieldSpec
+from .struct import StructTypeSpec
 from .union import UnionTypeSpec
 from ..errors import ThriftCompilerError
 from ..errors import UnknownExceptionError

--- a/thriftrw/spec/set.pyx
+++ b/thriftrw/spec/set.pyx
@@ -23,7 +23,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 import collections
 
 from thriftrw.wire cimport ttype
-from thriftrw.wire.value import SetValue
+from thriftrw.wire.value cimport SetValue
 
 from . import check
 from .base import TypeSpec

--- a/thriftrw/spec/union.pyx
+++ b/thriftrw/spec/union.pyx
@@ -21,12 +21,12 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 from thriftrw.wire cimport ttype
-from thriftrw.wire.value import StructValue
+from thriftrw.wire.value cimport StructValue
 
 from . import check
 from . import common
 from .base import TypeSpec
-from .struct import FieldSpec
+from .field import FieldSpec
 from ..errors import ThriftCompilerError
 
 __all__ = ['UnionTypeSpec', 'FieldSpec']


### PR DESCRIPTION
Also, for \*Value imports, use cimport since they're all defined in proper
cython modules. This improves performance *slightly* by avoiding some of the
Python overhead.