### PR TITLE
Add py.primitiveType annotation for enums

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Releases
 1.1.0 (unreleased)
 ------------------
 
+- Allow changing the primitive representation of enums with the
+  ``py.primitiveType`` annotation. See :ref:`annotations`.
 - Expose ``result_type`` on the args type for service functions.
 - Expose ``service`` on function spec.
 - Expose the contents of the Thrift file on compiled modules under the

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -515,6 +515,36 @@ without extra cost because the result is cached by the system.
 
     assert service.types is types
 
+.. _annotations:
+
+Customizing behavior with annotations
+-------------------------------------
+
+Thrift supports adding annotations to defined types, fields, references to
+primitive types, etc. These may be used to customize behavior of ``thriftrw``.
+
+The following annotations are supported by ``thriftrw``.
+
+``py.primitiveType``
+
+    Applies to enums only. This annotation may be used to change the primitive
+    representation of enums. Valid values are ``int`` (the default) and
+    ``string``.
+
+    For example::
+
+        enum Status {
+            QUEUED,
+            RUNNING,
+            FAILED,
+            SUCCEEDED,
+        } (py.primitiveType = "string")
+
+    The primitive representation of the items will now be ``"QUEUED"``,
+    ``"RUNNING"``, ``"FAILED"``, and ``"SUCCEEDED"``.
+
+    .. versionadded:: 1.1
+
 .. _calling-apache-thrift:
 
 Calling Apache Thrift

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ cython_modules = [
     'thriftrw._runtime',
     'thriftrw.protocol.core',
     'thriftrw.protocol.binary',
+    'thriftrw.spec.annotation',
     'thriftrw.spec.base',
     'thriftrw.spec.common',
     'thriftrw.spec.enum',

--- a/tests/spec/test_annotation.py
+++ b/tests/spec/test_annotation.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import, unicode_literals, print_function
+
+import pytest
+
+from thriftrw.idl import Parser
+from thriftrw.errors import ThriftCompilerError
+from thriftrw.spec.annotation import compile
+
+
+@pytest.fixture
+def parse():
+    """Parser for group of annotations."""
+    return Parser(start='annotations', silent=True).parse
+
+
+@pytest.fixture
+def load(parse):
+    def f(s):
+        return compile(parse(s))
+    return f
+
+
+def test_compile_none():
+    assert compile(None) == {}
+
+
+def test_load(load):
+    assert load('(a = "b", c, d = \'e\', f)') == {
+        'a': 'b', 'c': True, 'd': 'e', 'f': True
+    }
+
+
+def test_dupe(load):
+    with pytest.raises(ThriftCompilerError) as exc_info:
+        load('(a = "b", b, a = "c")')
+
+    assert 'Annotation "a"' in str(exc_info)
+    assert 'has duplicates' in str(exc_info)

--- a/thriftrw/spec/annotation.pyx
+++ b/thriftrw/spec/annotation.pyx
@@ -1,0 +1,42 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import, unicode_literals, print_function
+
+from ..errors import ThriftCompilerError
+
+
+def compile(annotations):
+    """Compiles a list of :py:class:`~thriftrw.idl.Annotation` objects into a
+    dictionary.
+    """
+    anns = {}
+    if not annotations:
+        return anns
+
+    for ann in annotations:
+        if ann.name in anns:
+            raise ThriftCompilerError(
+                'Annotation "%s" on line %d has duplicates.'
+                % (ann.name, ann.lineno)
+            )
+        anns[ann.name] = ann.value
+
+    return anns


### PR DESCRIPTION
The annotation customizes the primitive representation of enums. This will
allow users to say that ``to_primitive`` for enum values should not use the
numeric value of the enum but the name.

Resolves #56.