### PR TITLE
Support enum item value collision

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Releases
 - Don't fail compilation if fields in unions specify themselves as
   ``optional``.
 - Added ``i8`` as an alias for ``byte`` in Thrift files.
+- Allow multiple enum items to have the same value.
 - Fixed a bug where the line number of constant lists and maps was incorrect in
   the AST.
 

--- a/tests/spec/test_enum.py
+++ b/tests/spec/test_enum.py
@@ -69,14 +69,13 @@ def test_compile_duplicate_names(parse):
     assert 'has duplicates' in str(exc_info)
 
 
-def test_compile_values_collide():
-    with pytest.raises(ThriftCompilerError) as exc_info:
-        EnumTypeSpec(
-            'TestEnum',
-            {'A': 1, 'B': 5, 'C': 1},
-        )
+def test_compile_values_collide(parse):
+    enum_ast = parse('enum Foo { A, B, C = 0, D }')
+    spec = EnumTypeSpec.compile(enum_ast)
 
-    assert 'Enums items cannot share values' in str(exc_info)
+    assert spec.items == {'A': 0, 'B': 1, 'C': 0, 'D': 1}
+    assert set(spec.values_to_names[0]) == set(['A', 'C'])
+    assert set(spec.values_to_names[1]) == set(['B', 'D'])
 
 
 def test_link(loads):


### PR DESCRIPTION
Enums were previously not fully compliant with what Apache Thrift does.
The system would barf if multiple enum items had the same value. This fixes
this behavior for thriftrw-python. (thriftrw-node is already doing the right
thing.)