### PR TITLE
Expose the Protocol on $module.{dumps,loads}

### DIFF
--- a/tests/spec/test_struct.py
+++ b/tests/spec/test_struct.py
@@ -158,7 +158,8 @@ def test_load_simple(loads):
     obj = SimpleStruct('hello', 42)
     assert obj.a == 'hello'
     assert obj.c == 42
-    assert None == obj.b == obj.d
+    assert obj.b is None
+    assert obj.d is None
 
     obj = SimpleStruct(c=42, a='hello', b=b'world', d=2)
     assert obj.a == 'hello'

--- a/thriftrw/_runtime.pxd
+++ b/thriftrw/_runtime.pxd
@@ -27,7 +27,7 @@ from thriftrw.protocol.core cimport Protocol
 
 
 cdef class Serializer(object):
-    cdef Protocol protocol
+    cdef readonly Protocol protocol
 
     cpdef bytes dumps(self, obj)
 
@@ -35,7 +35,7 @@ cdef class Serializer(object):
 
 
 cdef class Deserializer(object):
-    cdef Protocol protocol
+    cdef readonly Protocol protocol
 
     cpdef object loads(self, obj_cls, bytes s)
 


### PR DESCRIPTION
This allows you to do:

    my_module = thriftrw.load(..)
    my_module.dumps.protocol

If you need to access the protocol associated with the module.

Use case: If you are doing low level stuff directly with the message/etc. you want to be sure you're using the same Protocol as the generated module.