### PR TITLE
Reduce Python interaction during serialization

### DIFF
--- a/tests/protocol/test_binary.py
+++ b/tests/protocol/test_binary.py
@@ -460,22 +460,3 @@ def test_message_invalid_version(bs):
         BinaryProtocol().deserialize_message(bs)
 
     assert 'Unsupported version "42"' in str(exc_info)
-
-
-@pytest.mark.parametrize('bs', [
-    [
-        0x80, 0x01,  # version = 1
-        0x00, 0x05,  # type = invalid
-        0x00, 0x00, 0x00, 0x06,                 # length = 6
-        0x67, 0x65, 0x74, 0x46, 0x6f, 0x6f,     # 'getFoo'
-        0x00, 0x00, 0x00, 0x01,     # seqId = 1
-        0x00,   # STOP
-    ]
-])
-def test_message_invalid_message_type(bs):
-    bs = bytes(bytearray(bs))
-
-    with pytest.raises(ThriftProtocolError) as exc_info:
-        BinaryProtocol().deserialize_message(bs)
-
-    assert 'Unknown message type "5"' in str(exc_info)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -35,20 +35,19 @@ def struct(module):
     Struct = module.Struct
 
     return Struct(
-        strings=['foo'] * 100,
-        ints=set([256] * 100),
-        mapped={n: 'bar' for n in range(100)},
+        strings=['foo'] * 100000,
+        ints=set([256] * 100000),
+        mapped={n: 'bar' for n in range(100000)},
     )
 
 
 def test_binary_dumps(benchmark, module, struct):
-    benchmark(lambda: module.dumps(struct))
+    benchmark(module.dumps, struct)
 
 
 def test_binary_loads(benchmark, module, struct):
     serialized = module.dumps(struct)
-
-    benchmark(lambda: module.loads(struct.__class__, serialized))
+    benchmark(module.loads, struct.__class__, serialized)
 
 
 def test_to_primitive(benchmark, struct):
@@ -57,5 +56,4 @@ def test_to_primitive(benchmark, struct):
 
 def test_from_primitive(benchmark, struct):
     primitive = struct.to_primitive()
-
-    benchmark(lambda: struct.type_spec.from_primitive(primitive))
+    benchmark(struct.type_spec.from_primitive, primitive)

--- a/tests/wire/test_value.py
+++ b/tests/wire/test_value.py
@@ -24,7 +24,7 @@ import pytest
 
 from thriftrw.wire import value
 from thriftrw.wire import ttype
-from thriftrw.wire.value import ValueVisitor
+from thriftrw.wire.value import _ValueVisitorArgs
 
 
 @pytest.mark.parametrize('value, visit_name, visit_args', [
@@ -76,18 +76,13 @@ from thriftrw.wire.value import ValueVisitor
 def test_visitors(value, visit_name, visit_args):
     """Checks that for each value type, the correct visitor is called."""
 
-    class MockVisitor(ValueVisitor):
-        pass
+    visitor = _ValueVisitorArgs()
+    result = value.apply(visitor)
+    name = result[0]
+    args = result[1:]
 
-    visitor = MockVisitor()
-
-    def visit(*args):
-        assert args == visit_args
-        return 'hello'
-
-    setattr(visitor, visit_name, visit)
-
-    assert 'hello' == value.apply(visitor)
+    assert visit_name == name
+    assert visit_args == args
 
 
 def test_struct_get():

--- a/thriftrw/protocol/binary.pxd
+++ b/thriftrw/protocol/binary.pxd
@@ -20,10 +20,87 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
+from libc.stdint cimport (
+    int8_t,
+    int16_t,
+    int32_t,
+    int64_t,
+)
+
 from thriftrw.protocol.core cimport Protocol
 from thriftrw.wire.message cimport Message
-from thriftrw.wire.value cimport Value
+from thriftrw._buffer cimport ReadBuffer, WriteBuffer
+from thriftrw.wire.value cimport (
+    ValueVisitor,
+    Value,
+    BoolValue,
+    ByteValue,
+    DoubleValue,
+    I16Value,
+    I32Value,
+    I64Value,
+    BinaryValue,
+    FieldValue,
+    StructValue,
+    MapValue,
+    MapItem,
+    SetValue,
+    ListValue,
+)
 
 
 cdef class BinaryProtocol(Protocol):
     pass
+
+cdef class BinaryProtocolReader(object):
+    cdef ReadBuffer reader
+
+    cdef object _reader(self, int8_t typ)
+
+    cpdef object read(self, int8_t typ)
+
+    cdef void _read(self, char* data, int count) except *
+
+    cdef int8_t _byte(self) except *
+
+    cdef int16_t _i16(self) except *
+
+    cdef int32_t _i32(self) except *
+
+    cdef int64_t _i64(self) except *
+
+    cdef double _double(self) except *
+
+    cdef Message read_message(self)
+
+    cdef BoolValue read_bool(self)
+
+    cdef ByteValue read_byte(self)
+
+    cdef DoubleValue read_double(self)
+
+    cdef I16Value read_i16(self)
+
+    cdef I32Value read_i32(self)
+
+    cdef I64Value read_i64(self)
+
+    cdef BinaryValue read_binary(self)
+
+    cdef StructValue read_struct(self)
+
+    cdef MapValue read_map(self)
+
+    cdef SetValue read_set(self)
+
+    cdef ListValue read_list(self)
+
+
+cdef class BinaryProtocolWriter(ValueVisitor):
+    cdef WriteBuffer writer
+
+    cpdef void write(self, Value value)
+
+    cdef _write(self, char* data, int length)
+
+    cdef void write_message(self, Message message) except *

--- a/thriftrw/wire/value.pxd
+++ b/thriftrw/wire/value.pxd
@@ -30,75 +30,65 @@ from libc.stdint cimport (
 
 cdef class ValueVisitor(object):
 
-    cpdef object visit_bool(self, bint value)
+    cdef object visit_bool(self, bint value)
 
-    cpdef object visit_byte(self, int8_t value)
+    cdef object visit_byte(self, int8_t value)
 
-    cpdef object visit_double(self, double value)
+    cdef object visit_double(self, double value)
 
-    cpdef object visit_i16(self, int16_t value)
+    cdef object visit_i16(self, int16_t value)
 
-    cpdef object visit_i32(self, int32_t value)
+    cdef object visit_i32(self, int32_t value)
 
-    cpdef object visit_i64(self, int64_t value)
+    cdef object visit_i64(self, int64_t value)
 
-    cpdef object visit_binary(self, bytes value)
+    cdef object visit_binary(self, bytes value)
 
-    cpdef object visit_struct(self, list fields)
+    cdef object visit_struct(self, list fields)
 
-    cpdef object visit_map(self, int8_t key_ttype, int8_t value_ttype, list pairs)
+    cdef object visit_map(self, int8_t key_ttype, int8_t value_ttype, list pairs)
 
-    cpdef object visit_set(self, int8_t value_ttype, list values)
+    cdef object visit_set(self, int8_t value_ttype, list values)
 
-    cpdef object visit_list(self, int8_t value_ttype, list values)
+    cdef object visit_list(self, int8_t value_ttype, list values)
+
+
+cdef class _ValueVisitorArgs(ValueVisitor):
+    pass
 
 
 cdef class Value(object):
 
-    cpdef object apply(self, visitor)
+    cpdef object apply(Value self, ValueVisitor visitor)
 
 
 cdef class BoolValue(Value):
     cdef readonly bint value
 
-    cpdef object apply(self, visitor)
-
 
 cdef class ByteValue(Value):
     cdef readonly int8_t value
-
-    cpdef object apply(self, visitor)
 
 
 cdef class DoubleValue(Value):
     cdef readonly double value
 
-    cpdef object apply(self, visitor)
-
 
 cdef class I16Value(Value):
     cdef readonly int16_t value
-
-    cpdef object apply(self, visitor)
 
 
 cdef class I32Value(Value):
     cdef readonly int32_t value
 
-    cpdef object apply(self, visitor)
-
 
 cdef class I64Value(Value):
     cdef readonly int64_t value
-
-    cpdef object apply(self, visitor)
 
 
 cdef class BinaryValue(Value):
     cdef readonly bytes value
     # TODO change to char* once BinaryProtocol knows how to write that.
-
-    cpdef object apply(self, visitor)
 
 
 cdef class FieldValue(object):
@@ -111,8 +101,6 @@ cdef class StructValue(Value):
     cdef readonly list fields
     cdef readonly dict _index
 
-    cpdef object apply(self, visitor)
-
 
 cdef class MapItem(object):
     cdef readonly object key
@@ -124,18 +112,12 @@ cdef class MapValue(Value):
     cdef readonly int8_t value_ttype
     cdef readonly list pairs
 
-    cpdef object apply(self, visitor)
-
 
 cdef class SetValue(Value):
     cdef readonly int8_t value_ttype
     cdef readonly list values
 
-    cpdef object apply(self, visitor)
-
 
 cdef class ListValue(Value):
     cdef readonly int8_t value_ttype
     cdef readonly list values
-
-    cpdef object apply(self, visitor)

--- a/thriftrw/wire/value.pyx
+++ b/thriftrw/wire/value.pyx
@@ -56,7 +56,7 @@ cdef class Value(object):
     they are sent and received over the wire.
     """
 
-    cpdef object apply(self, visitor):
+    cpdef object apply(Value self, ValueVisitor visitor):
         """Apply the value to the given visitor.
 
         The appropriate `visit_*` method will be called and its result
@@ -75,7 +75,7 @@ cdef class BoolValue(Value):
 
     ttype_code = ttype.BOOL
 
-    def __cinit__(self, bint value):
+    def __cinit__(BoolValue self, bint value):
         self.value = value
 
     def __richcmp__(BoolValue self, BoolValue other not None, int op):
@@ -87,7 +87,7 @@ cdef class BoolValue(Value):
     def __repr__(self):
         return str(self)
 
-    cpdef object apply(self, visitor):
+    cpdef object apply(BoolValue self, ValueVisitor visitor):
         return visitor.visit_bool(self.value)
 
 
@@ -96,7 +96,7 @@ cdef class ByteValue(Value):
 
     ttype_code = ttype.BYTE
 
-    def __cinit__(self, int8_t value):
+    def __cinit__(ByteValue self, int8_t value):
         self.value = value
 
     def __richcmp__(ByteValue self, ByteValue other not None, int op):
@@ -108,7 +108,7 @@ cdef class ByteValue(Value):
     def __repr__(self):
         return str(self)
 
-    cpdef object apply(self, visitor):
+    cpdef object apply(ByteValue self, ValueVisitor visitor):
         return visitor.visit_byte(self.value)
 
 
@@ -117,7 +117,7 @@ cdef class DoubleValue(Value):
 
     ttype_code = ttype.DOUBLE
 
-    def __cinit__(self, double value):
+    def __cinit__(DoubleValue self, double value):
         self.value = value
 
     def __richcmp__(DoubleValue self, DoubleValue other not None, int op):
@@ -129,7 +129,7 @@ cdef class DoubleValue(Value):
     def __repr__(self):
         return str(self)
 
-    cpdef object apply(self, visitor):
+    cpdef object apply(DoubleValue self, ValueVisitor visitor):
         return visitor.visit_double(self.value)
 
 
@@ -138,7 +138,7 @@ cdef class I16Value(Value):
 
     ttype_code = ttype.I16
 
-    def __cinit__(self, int16_t value):
+    def __cinit__(I16Value self, int16_t value):
         self.value = value
 
     def __richcmp__(I16Value self, I16Value other not None, int op):
@@ -150,7 +150,7 @@ cdef class I16Value(Value):
     def __repr__(self):
         return str(self)
 
-    cpdef object apply(self, visitor):
+    cpdef object apply(I16Value self, ValueVisitor visitor):
         return visitor.visit_i16(self.value)
 
 
@@ -159,7 +159,7 @@ cdef class I32Value(Value):
 
     ttype_code = ttype.I32
 
-    def __cinit__(self, int value):
+    def __cinit__(I32Value self, int value):
         self.value = value
 
     def __richcmp__(I32Value self, I32Value other not None, int op):
@@ -171,7 +171,7 @@ cdef class I32Value(Value):
     def __repr__(self):
         return str(self)
 
-    cpdef object apply(self, visitor):
+    cpdef object apply(I32Value self, ValueVisitor visitor):
         return visitor.visit_i32(self.value)
 
 
@@ -180,7 +180,7 @@ cdef class I64Value(Value):
 
     ttype_code = ttype.I64
 
-    def __cinit__(self, long value):
+    def __cinit__(I64Value self, long value):
         self.value = value
 
     def __richcmp__(I64Value self, I64Value other not None, int op):
@@ -192,7 +192,7 @@ cdef class I64Value(Value):
     def __repr__(self):
         return str(self)
 
-    cpdef object apply(self, visitor):
+    cpdef object apply(I64Value self, ValueVisitor visitor):
         return visitor.visit_i64(self.value)
 
 
@@ -205,7 +205,7 @@ cdef class BinaryValue(Value):
 
     ttype_code = ttype.BINARY
 
-    def __cinit__(self, bytes value):
+    def __cinit__(BinaryValue self, bytes value):
         self.value = value
 
     def __richcmp__(BinaryValue self, BinaryValue other not None, int op):
@@ -217,7 +217,7 @@ cdef class BinaryValue(Value):
     def __repr__(self):
         return str(self)
 
-    cpdef object apply(self, visitor):
+    cpdef object apply(BinaryValue self, ValueVisitor visitor):
         return visitor.visit_binary(self.value)
 
 
@@ -237,7 +237,7 @@ cdef class FieldValue(object):
         Value for this field.
     """
 
-    def __cinit__(self, int16_t id, int8_t ttype, value):
+    def __cinit__(FieldValue self, int16_t id, int8_t ttype, value):
         self.id = id
         self.ttype = ttype
         self.value = value
@@ -266,7 +266,7 @@ cdef class StructValue(Value):
 
     ttype_code = ttype.STRUCT
 
-    def __cinit__(self, list fields):
+    def __cinit__(StructValue self, list fields):
         self.fields = fields
 
     def __init__(self, list fields):
@@ -274,7 +274,7 @@ cdef class StructValue(Value):
         for field in fields:
             self._index[(field.id, field.ttype)] = field
 
-    cpdef object apply(self, visitor):
+    cpdef object apply(StructValue self, ValueVisitor visitor):
         return visitor.visit_struct(self.fields)
 
     def get(self, field_id, field_ttype):
@@ -315,7 +315,7 @@ cdef class MapItem(object):
         Value associated with the key
     """
 
-    def __cinit__(self, key, value):
+    def __cinit__(MapItem self, key, value):
         self.key = key
         self.value = value
 
@@ -352,7 +352,7 @@ cdef class MapValue(Value):
 
     ttype_code = ttype.MAP
 
-    def __cinit__(self, int8_t key_ttype, int8_t value_ttype, list pairs):
+    def __cinit__(MapValue self, int8_t key_ttype, int8_t value_ttype, list pairs):
         self.key_ttype = key_ttype
         self.value_ttype = value_ttype
         self.pairs = pairs
@@ -370,7 +370,7 @@ cdef class MapValue(Value):
     def __repr__(self):
         return str(self)
 
-    cpdef object apply(self, visitor):
+    cpdef object apply(MapValue self, ValueVisitor visitor):
         return visitor.visit_map(self.key_ttype, self.value_ttype, self.pairs)
 
 
@@ -388,7 +388,7 @@ cdef class SetValue(Value):
 
     ttype_code = ttype.SET
 
-    def __cinit__(self, int8_t value_ttype, list values):
+    def __cinit__(SetValue self, int8_t value_ttype, list values):
         self.value_ttype = value_ttype
         self.values = values
 
@@ -404,7 +404,7 @@ cdef class SetValue(Value):
             (self.values, other.values),
         ])
 
-    cpdef object apply(self, visitor):
+    cpdef object apply(SetValue self, ValueVisitor visitor):
         return visitor.visit_set(self.value_ttype, self.values)
 
 
@@ -422,7 +422,7 @@ cdef class ListValue(Value):
 
     ttype_code = ttype.LIST
 
-    def __cinit__(self, int8_t value_ttype, list values):
+    def __cinit__(ListValue self, int8_t value_ttype, list values):
         self.value_ttype = value_ttype
         self.values = values
 
@@ -438,7 +438,7 @@ cdef class ListValue(Value):
             (self.values, other.values),
         ])
 
-    cpdef object apply(self, visitor):
+    cpdef object apply(ListValue self, ValueVisitor visitor):
         return visitor.visit_list(self.value_ttype, self.values)
 
 
@@ -454,7 +454,7 @@ cdef class ValueVisitor(object):
     here is to avoid ``isinstance`` checks.
     """
 
-    cpdef object visit_bool(self, bint value):
+    cdef object visit_bool(self, bint value):
         """Visits boolean values.
 
         :param bool value:
@@ -462,7 +462,7 @@ cdef class ValueVisitor(object):
         """
         raise NotImplementedError
 
-    cpdef object visit_byte(self, int8_t value):
+    cdef object visit_byte(self, int8_t value):
         """Visits 8-bit integers.
 
         :param int value:
@@ -470,7 +470,7 @@ cdef class ValueVisitor(object):
         """
         raise NotImplementedError
 
-    cpdef object visit_double(self, double value):
+    cdef object visit_double(self, double value):
         """Visits double values.
 
         :param float value:
@@ -478,7 +478,7 @@ cdef class ValueVisitor(object):
         """
         raise NotImplementedError
 
-    cpdef object visit_i16(self, int16_t value):
+    cdef object visit_i16(self, int16_t value):
         """Visits 16-bit integers.
 
         :param int value:
@@ -486,7 +486,7 @@ cdef class ValueVisitor(object):
         """
         raise NotImplementedError
 
-    cpdef object visit_i32(self, int32_t value):
+    cdef object visit_i32(self, int32_t value):
         """Visits 32-bit integers.
 
         :param int value:
@@ -494,7 +494,7 @@ cdef class ValueVisitor(object):
         """
         raise NotImplementedError
 
-    cpdef object visit_i64(self, int64_t value):
+    cdef object visit_i64(self, int64_t value):
         """Visits 64-bit integers.
 
         :param int value:
@@ -502,7 +502,7 @@ cdef class ValueVisitor(object):
         """
         raise NotImplementedError
 
-    cpdef object visit_binary(self, bytes value):
+    cdef object visit_binary(self, bytes value):
         """Visits binary blobs.
 
         :param bytes value:
@@ -510,7 +510,7 @@ cdef class ValueVisitor(object):
         """
         raise NotImplementedError
 
-    cpdef object visit_struct(self, list fields):
+    cdef object visit_struct(self, list fields):
         """Visits structs.
 
         :param fields:
@@ -518,7 +518,7 @@ cdef class ValueVisitor(object):
         """
         raise NotImplementedError
 
-    cpdef object visit_map(
+    cdef object visit_map(
         self, int8_t key_ttype, int8_t value_ttype, list pairs
     ):
         """Visits maps.
@@ -532,7 +532,7 @@ cdef class ValueVisitor(object):
         """
         raise NotImplementedError
 
-    cpdef object visit_set(self, int8_t value_ttype, list values):
+    cdef object visit_set(self, int8_t value_ttype, list values):
         """Visits sets.
 
         :param thriftrw.wire.TType value_ttype:
@@ -542,7 +542,7 @@ cdef class ValueVisitor(object):
         """
         raise NotImplementedError
 
-    cpdef object visit_list(self, int8_t value_ttype, list values):
+    cdef object visit_list(self, int8_t value_ttype, list values):
         """Visits lists.
 
         :param thriftrw.wire.TType value_ttype:
@@ -551,3 +551,46 @@ cdef class ValueVisitor(object):
             Collection of values in the list.
         """
         raise NotImplementedError
+
+
+cdef class _ValueVisitorArgs(ValueVisitor):
+    """A ValueVisitor that simply returns the arguments for a visitor along
+    with its name.
+
+    This is meant for testing only.
+    """
+
+    cdef object visit_bool(self, bint value):
+        return ('visit_bool', value)
+
+    cdef object visit_byte(self, int8_t value):
+        return ('visit_byte', value)
+
+    cdef object visit_double(self, double value):
+        return ('visit_double', value)
+
+    cdef object visit_i16(self, int16_t value):
+        return ('visit_i16', value)
+
+    cdef object visit_i32(self, int32_t value):
+        return ('visit_i32', value)
+
+    cdef object visit_i64(self, int64_t value):
+        return ('visit_i64', value)
+
+    cdef object visit_binary(self, bytes value):
+        return ('visit_binary', value)
+
+    cdef object visit_struct(self, list fields):
+        return ('visit_struct', fields)
+
+    cdef object visit_map(
+        self, int8_t key_ttype, int8_t value_ttype, list pairs
+    ):
+        return ('visit_map', key_ttype, value_ttype, pairs)
+
+    cdef object visit_set(self, int8_t value_ttype, list values):
+        return ('visit_set', value_ttype, values)
+
+    cdef object visit_list(self, int8_t value_ttype, list values):
+        return ('visit_list', value_ttype, values)


### PR DESCRIPTION
This very slightly improves the serialization performance.

Before:
```
--------------------------------------------- benchmark: 2 tests ---------------------------------------------
Name (time in ms)          Min       Max      Mean  StdDev    Median      IQR  Outliers(*)  Rounds  Iterations
--------------------------------------------------------------------------------------------------------------
test_binary_dumps     123.0109  130.0850  125.1512  2.0382  124.6510   1.6854          6;3      25           1
test_binary_loads     489.0878  517.9942  501.0961  7.9750  500.0012  12.7176          9;0      25           1
--------------------------------------------------------------------------------------------------------------
```

After:
```
--------------------------------------------- benchmark: 2 tests --------------------------------------------
Name (time in ms)          Min       Max      Mean  StdDev    Median     IQR  Outliers(*)  Rounds  Iterations
-------------------------------------------------------------------------------------------------------------
test_binary_dumps     113.8060  124.3708  116.9059  3.3549  115.5560  1.4975          5;5      25           1
test_binary_loads     490.5999  505.4250  496.1776  3.5518  495.6250  4.5011          8;1      25           1
-------------------------------------------------------------------------------------------------------------
```
